### PR TITLE
#17 feat: 간편 로그인 email -> auth id로 유저 식별 기준 변경

### DIFF
--- a/src/main/java/com/floney/floney/user/client/ClientProxy.java
+++ b/src/main/java/com/floney/floney/user/client/ClientProxy.java
@@ -2,6 +2,6 @@ package com.floney.floney.user.client;
 
 public interface ClientProxy {
 
-    String getEmail(String authToken);
+    void init(String authToken);
 
 }

--- a/src/main/java/com/floney/floney/user/client/GoogleClient.java
+++ b/src/main/java/com/floney/floney/user/client/GoogleClient.java
@@ -3,15 +3,21 @@ package com.floney.floney.user.client;
 import com.floney.floney.common.exception.OAuthResponseException;
 import com.floney.floney.user.dto.response.GoogleUserResponse;
 import java.net.URI;
+import lombok.Getter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+@Getter
 @Component
 public class GoogleClient implements ClientProxy {
 
+    private Long id;
+    private String email;
+    private String nickname;
+
     @Override
-    public String getEmail(String authToken) {
+    public void init(String authToken) {
         URI uri = UriComponentsBuilder
                 .fromUriString("https://oauth2.googleapis.com")
                 .path("/tokeninfo")
@@ -24,9 +30,11 @@ public class GoogleClient implements ClientProxy {
         if(result == null) {
             throw new OAuthResponseException();
         }
-        result.validate();
 
-        return result.getEmail();
+        this.id = result.getSub();
+        this.email = result.getEmail();
+        this.nickname = result.getName();
+
     }
 
 }

--- a/src/main/java/com/floney/floney/user/client/KakaoClient.java
+++ b/src/main/java/com/floney/floney/user/client/KakaoClient.java
@@ -4,15 +4,21 @@ import com.floney.floney.common.exception.OAuthResponseException;
 import com.floney.floney.user.dto.response.KakaoUserResponse;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import lombok.Getter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+@Getter
 @Component
 public class KakaoClient implements ClientProxy {
 
+    private Long id;
+    private String email;
+    private String nickname;
+
     @Override
-    public String getEmail(String authToken) {
+    public void init(String authToken) {
         URI uri = UriComponentsBuilder
                 .fromUriString("https://kapi.kakao.com")
                 .path("/v2/user/me")
@@ -25,9 +31,11 @@ public class KakaoClient implements ClientProxy {
         if(result == null) {
             throw new OAuthResponseException();
         }
-        result.validate();
 
-        return result.getKakaoAccount().getEmail();
+        this.id = result.getId();
+        this.email = result.getKakaoAccount().getEmail();
+        this.nickname = result.getKakaoAccount().getProfile().getNickname();
+
     }
 
 }

--- a/src/main/java/com/floney/floney/user/controller/AuthController.java
+++ b/src/main/java/com/floney/floney/user/controller/AuthController.java
@@ -1,0 +1,14 @@
+package com.floney.floney.user.controller;
+
+import com.floney.floney.user.dto.request.SignupRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface AuthController {
+
+    ResponseEntity<?> checkIfSignup(@RequestParam String token);
+    ResponseEntity<?> signup(@RequestParam String token, @RequestBody SignupRequest request);
+    ResponseEntity<?> login(@RequestParam String token);
+
+}

--- a/src/main/java/com/floney/floney/user/controller/GoogleController.java
+++ b/src/main/java/com/floney/floney/user/controller/GoogleController.java
@@ -1,0 +1,39 @@
+package com.floney.floney.user.controller;
+
+import com.floney.floney.user.dto.request.SignupRequest;
+import com.floney.floney.user.service.GoogleUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/auth/google")
+@RequiredArgsConstructor
+public class GoogleController implements AuthController {
+
+    private final GoogleUserService googleUserService;
+
+    @Override
+    @GetMapping("/check")
+    public ResponseEntity<?> checkIfSignup(String token) {
+        return new ResponseEntity<>(googleUserService.checkIfSignup(token), HttpStatus.OK);
+    }
+
+    @Override
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(String token, SignupRequest request) {
+        googleUserService.signup(token, request);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @Override
+    @GetMapping("/login")
+    public ResponseEntity<?> login(String token) {
+        return new ResponseEntity<>(googleUserService.login(token), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/floney/floney/user/controller/KakaoController.java
+++ b/src/main/java/com/floney/floney/user/controller/KakaoController.java
@@ -1,0 +1,39 @@
+package com.floney.floney.user.controller;
+
+import com.floney.floney.user.dto.request.SignupRequest;
+import com.floney.floney.user.service.KakaoUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/auth/kakao")
+@RequiredArgsConstructor
+public class KakaoController implements AuthController {
+
+    private final KakaoUserService kakaoUserService;
+
+    @Override
+    @GetMapping("/check")
+    public ResponseEntity<?> checkIfSignup(String token) {
+        return new ResponseEntity<>(kakaoUserService.checkIfSignup(token), HttpStatus.OK);
+    }
+
+    @Override
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(String token, SignupRequest request) {
+        kakaoUserService.signup(token, request);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @Override
+    @GetMapping("/login")
+    public ResponseEntity<?> login(String token) {
+        return new ResponseEntity<>(kakaoUserService.login(token), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/floney/floney/user/controller/UserController.java
+++ b/src/main/java/com/floney/floney/user/controller/UserController.java
@@ -4,7 +4,6 @@ import com.floney.floney.common.token.dto.Token;
 import com.floney.floney.user.dto.request.EmailAuthenticationRequest;
 import com.floney.floney.user.dto.request.LoginRequest;
 import com.floney.floney.user.dto.request.SignupRequest;
-import com.floney.floney.user.service.OAuthUserService;
 import com.floney.floney.user.service.UserService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +18,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/users")
+@RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
-    private final OAuthUserService oAuthUserService;
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody @Valid SignupRequest signupRequest) {
@@ -93,22 +91,6 @@ public class UserController {
     @GetMapping("/mypage")
     public ResponseEntity<?> getMyPage(@AuthenticationPrincipal UserDetails userDetail) {
         return new ResponseEntity<>(userService.getUserInfo(userDetail.getUsername()), HttpStatus.OK);
-    }
-
-    @GetMapping("/email")
-    public ResponseEntity<?> validateIfNewUser(@RequestParam String email) {
-        userService.validateIfNewUser(email);
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
-
-    @GetMapping("/login/kakao")
-    public ResponseEntity<?> kakaoLogin(@RequestParam String token) {
-        return new ResponseEntity<>(oAuthUserService.kakaoLogin(token), HttpStatus.OK);
-    }
-
-    @GetMapping("/login/google")
-    public ResponseEntity<?> googleLogin(@RequestParam String token) {
-        return new ResponseEntity<>(oAuthUserService.googleLogin(token), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/floney/floney/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/floney/floney/user/dto/request/SignupRequest.java
@@ -36,4 +36,14 @@ public class SignupRequest {
                 .build();
     }
 
+    public User to(Long providerId) {
+        return User.oAuthBuilder()
+                .email(email)
+                .nickname(nickname)
+                .marketingAgree(marketingAgree)
+                .provider(Provider.findByName(provider))
+                .providerId(providerId)
+                .build();
+    }
+
 }

--- a/src/main/java/com/floney/floney/user/dto/response/GoogleUserResponse.java
+++ b/src/main/java/com/floney/floney/user/dto/response/GoogleUserResponse.java
@@ -14,14 +14,9 @@ import lombok.NoArgsConstructor;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GoogleUserResponse {
 
+    private Long sub;
     private String email;
     private boolean emailVerified;
     private String name;
-
-    public void validate() {
-        if (!emailVerified) {
-            throw new EmailNotValidException();
-        }
-    }
 
 }

--- a/src/main/java/com/floney/floney/user/dto/response/KakaoUserResponse.java
+++ b/src/main/java/com/floney/floney/user/dto/response/KakaoUserResponse.java
@@ -36,14 +36,4 @@ public class KakaoUserResponse {
         private String nickname;
     }
 
-    public void validate() {
-        try {
-            if (!kakaoAccount.isEmailValid || !kakaoAccount.isEmailVerified) {
-                throw new EmailNotValidException();
-            }
-        } catch (NullPointerException exception) {
-            throw new OAuthResponseException();
-        }
-    }
-
 }

--- a/src/main/java/com/floney/floney/user/entity/User.java
+++ b/src/main/java/com/floney/floney/user/entity/User.java
@@ -51,6 +51,9 @@ public class User extends BaseEntity {
     @Column(nullable = false, updatable = false, length = 10)
     private String provider;
 
+    @Column(updatable = false, unique = true)
+    private Long providerId;
+
     @Builder(builderMethodName = "signupBuilder")
     private User(String email, String nickname, String password, boolean marketingAgree, Provider provider) {
         this.email = email;
@@ -61,9 +64,19 @@ public class User extends BaseEntity {
         this.provider = provider.getName();
     }
 
+    @Builder(builderMethodName = "oAuthBuilder")
+    private User(String email, String nickname, boolean marketingAgree, Provider provider, Long providerId) {
+        this.email = email;
+        this.nickname = nickname;
+        this.marketingAgree = marketingAgree;
+        this.lastAdTime = LocalDateTime.now();
+        this.provider = provider.getName();
+        this.providerId = providerId;
+    }
+
     @Builder
     private User(String email, String nickname, String password, String profileImg, boolean marketingAgree,
-                LocalDateTime lastAdTime, boolean subscribe, Provider provider) {
+                 LocalDateTime lastAdTime, boolean subscribe, Provider provider, Long providerId) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
@@ -72,6 +85,7 @@ public class User extends BaseEntity {
         this.lastAdTime = lastAdTime;
         this.subscribe = subscribe;
         this.provider = provider.getName();
+        this.providerId = providerId;
     }
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
@@ -90,10 +104,12 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
-    public boolean isSubscribe(){
+    public boolean isSubscribe() {
         return subscribe;
     }
+
     public void updateProfileImg(String profileImg) {
         this.profileImg = profileImg;
     }
+
 }

--- a/src/main/java/com/floney/floney/user/repository/UserRepository.java
+++ b/src/main/java/com/floney/floney/user/repository/UserRepository.java
@@ -10,4 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findUserByEmailAndStatus(String email,Boolean status);
+    boolean existsByProviderId(Long providerId);
+    Optional<User> findByProviderId(Long providerId);
+
 }

--- a/src/main/java/com/floney/floney/user/service/GoogleUserService.java
+++ b/src/main/java/com/floney/floney/user/service/GoogleUserService.java
@@ -1,0 +1,54 @@
+package com.floney.floney.user.service;
+
+import com.floney.floney.common.exception.UserNotFoundException;
+import com.floney.floney.common.token.JwtProvider;
+import com.floney.floney.common.token.dto.Token;
+import com.floney.floney.user.client.GoogleClient;
+import com.floney.floney.user.client.KakaoClient;
+import com.floney.floney.user.dto.request.SignupRequest;
+import com.floney.floney.user.entity.User;
+import com.floney.floney.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleUserService implements OAuthUserService {
+
+    private final GoogleClient googleClient;
+    private final JwtProvider jwtProvider;
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean checkIfSignup(String oAuthToken) {
+        return userRepository.existsByProviderId(getProviderId(oAuthToken));
+    }
+
+    @Override
+    public void signup(String oAuthToken, SignupRequest request) {
+        Long providerId = getProviderId(oAuthToken);
+        userRepository.save(request.to(providerId));
+    }
+
+    @Override
+    public Token login(String oAuthToken) {
+        Long providerId = getProviderId(oAuthToken);
+
+        User user = userRepository.findByProviderId(providerId).orElseThrow(UserNotFoundException::new);
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(user.getEmail(), null)
+        );
+
+        return jwtProvider.generateToken(authentication);
+    }
+
+    private Long getProviderId(String oAuthToken) {
+        googleClient.init(oAuthToken);
+        return googleClient.getId();
+    }
+
+}

--- a/src/main/java/com/floney/floney/user/service/KakaoUserService.java
+++ b/src/main/java/com/floney/floney/user/service/KakaoUserService.java
@@ -1,0 +1,55 @@
+package com.floney.floney.user.service;
+
+import com.floney.floney.common.exception.UserNotFoundException;
+import com.floney.floney.common.token.JwtProvider;
+import com.floney.floney.common.token.dto.Token;
+import com.floney.floney.user.client.GoogleClient;
+import com.floney.floney.user.client.KakaoClient;
+import com.floney.floney.user.dto.request.SignupRequest;
+import com.floney.floney.user.dto.response.KakaoUserResponse;
+import com.floney.floney.user.entity.User;
+import com.floney.floney.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoUserService implements OAuthUserService {
+
+    private final KakaoClient kakaoClient;
+    private final JwtProvider jwtProvider;
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean checkIfSignup(String oAuthToken) {
+        return userRepository.existsByProviderId(getProviderId(oAuthToken));
+    }
+
+    @Override
+    public void signup(String oAuthToken, SignupRequest request) {
+        Long providerId = getProviderId(oAuthToken);
+        userRepository.save(request.to(providerId));
+    }
+
+    @Override
+    public Token login(String oAuthToken) {
+        Long providerId = getProviderId(oAuthToken);
+
+        User user = userRepository.findByProviderId(providerId).orElseThrow(UserNotFoundException::new);
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(user.getEmail(), null)
+        );
+
+        return jwtProvider.generateToken(authentication);
+    }
+
+    private Long getProviderId(String oAuthToken) {
+        kakaoClient.init(oAuthToken);
+        return kakaoClient.getId();
+    }
+
+}

--- a/src/main/java/com/floney/floney/user/service/OAuthUserService.java
+++ b/src/main/java/com/floney/floney/user/service/OAuthUserService.java
@@ -1,38 +1,12 @@
 package com.floney.floney.user.service;
 
-import com.floney.floney.common.token.JwtProvider;
 import com.floney.floney.common.token.dto.Token;
-import com.floney.floney.user.client.GoogleClient;
-import com.floney.floney.user.client.KakaoClient;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Service;
+import com.floney.floney.user.dto.request.SignupRequest;
 
-@Service
-@RequiredArgsConstructor
-public class OAuthUserService {
+public interface OAuthUserService {
 
-    private final KakaoClient kakaoClient;
-    private final GoogleClient googleClient;
-    private final JwtProvider jwtProvider;
-    private final AuthenticationManager authenticationManager;
-
-    public Token kakaoLogin(String oAuthToken) {
-        String email = kakaoClient.getEmail(oAuthToken);
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(email, null)
-        );
-        return jwtProvider.generateToken(authentication);
-    }
-
-    public Token googleLogin(String oAuthToken) {
-        String email = googleClient.getEmail(oAuthToken);
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(email, null)
-        );
-        return jwtProvider.generateToken(authentication);
-    }
+    boolean checkIfSignup(String oAuthToken);
+    void signup(String oAuthToken, SignupRequest request);
+    Token login(String oAuthToken);
 
 }

--- a/src/test/java/com/floney/floney/User/controller/UserControllerTest.java
+++ b/src/test/java/com/floney/floney/User/controller/UserControllerTest.java
@@ -9,11 +9,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.floney.floney.common.exception.MailAddressException;
-import com.floney.floney.common.exception.OAuthResponseException;
-import com.floney.floney.common.exception.UserFoundException;
 import com.floney.floney.common.token.dto.Token;
 import com.floney.floney.user.dto.request.LoginRequest;
-import com.floney.floney.user.service.OAuthUserService;
+import com.floney.floney.user.service.KakaoUserService;
 import com.floney.floney.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,7 +34,7 @@ class UserControllerTest {
     @MockBean
     private UserService userService;
     @MockBean
-    private OAuthUserService oAuthUserService;
+    private KakaoUserService kakaoUserService;
 
     @Autowired
     public UserControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
@@ -115,30 +113,6 @@ class UserControllerTest {
         // when & then
         mockMvc.perform(get("/users/email/mail").queryParam("email", email))
                 .andExpect(status().isInternalServerError())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
-    }
-
-    @Test
-    @DisplayName("카카오 토큰 인증에 성공한다")
-    void kakaoLogin_success() throws Exception {
-        // given
-        given(oAuthUserService.kakaoLogin(anyString())).willReturn(new Token("", ""));
-
-        // when & then
-        mockMvc.perform(get("/users/login/kakao").queryParam("token", "token"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
-    }
-
-    @Test
-    @DisplayName("구글 토큰 인증에 성공한다")
-    void googleLogin_success() throws Exception {
-        // given
-        given(oAuthUserService.googleLogin(anyString())).willReturn(new Token("", ""));
-
-        // when & then
-        mockMvc.perform(get("/users/login/google").queryParam("token", "token"))
-                .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
     }
 


### PR DESCRIPTION
## 📚 이슈 번호
#17

## 📝 데이터베이스 변경 사항
- User에 providerId 추가

## 💬 기타 사항
- 프론트랑 직접 테스팅 해봐야 함
- 일반 회원과 간편 회원 간 이메일 충돌 처리 해야함
