### PR TITLE
204 feat: 회원 탈퇴 사유 저장

### DIFF
--- a/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
@@ -17,6 +17,7 @@ import com.floney.floney.common.exception.user.MailAddressException;
 import com.floney.floney.common.exception.user.NotFoundSubscribeException;
 import com.floney.floney.common.exception.user.OAuthResponseException;
 import com.floney.floney.common.exception.user.OAuthTokenNotValidException;
+import com.floney.floney.common.exception.user.SignoutOtherReasonEmptyException;
 import com.floney.floney.common.exception.user.UserFoundException;
 import com.floney.floney.common.exception.user.UserNotFoundException;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -124,6 +125,13 @@ public class ErrorControllerAdvice {
     protected ResponseEntity<ErrorResponse> invalidOAuthToken(OAuthTokenNotValidException exception) {
         logger.warn("외부 로그인 서버에서 잘못된 토큰으로 인한 인증 실패");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of(exception.getErrorType()));
+    }
+
+    @ExceptionHandler(SignoutOtherReasonEmptyException.class)
+    protected ResponseEntity<ErrorResponse> signoutOtherReasonEmpty(SignoutOtherReasonEmptyException exception) {
+        logger.warn("회원 탈퇴 요청에서 value가 비어있음");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(exception.getErrorType()));
     }
 

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorType.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorType.java
@@ -27,6 +27,7 @@ public enum ErrorType {
     INVALID_OAUTH_TOKEN("U016", "provider 토큰이 올바르지 않습니다"),
     SAME_PASSWORD("U017", "이전 비밀번호와 같습니다"),
     CODE_NOT_FOUND("U018", "코드가 존재하지 않습니다"),
+    EMPTY_SIGNOUT_OTHER_REASON("U019", "기타 탈퇴 사유가 없습니다"),
 
     NOT_FOUND_BOOK("B001", "가계부가 존재하지 않습니다"),
     MAX_MEMBER("B002", "최대 인원이 초과되었습니다"),

--- a/src/main/java/com/floney/floney/common/exception/user/SignoutOtherReasonEmptyException.java
+++ b/src/main/java/com/floney/floney/common/exception/user/SignoutOtherReasonEmptyException.java
@@ -1,0 +1,14 @@
+package com.floney.floney.common.exception.user;
+
+import com.floney.floney.common.exception.common.ErrorType;
+import lombok.Getter;
+
+@Getter
+public class SignoutOtherReasonEmptyException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    public SignoutOtherReasonEmptyException() {
+        this.errorType = ErrorType.EMPTY_SIGNOUT_OTHER_REASON;
+    }
+}

--- a/src/main/java/com/floney/floney/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/floney/floney/settlement/repository/SettlementRepository.java
@@ -6,10 +6,9 @@ import com.floney.floney.settlement.domain.entity.Settlement;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-public interface SettlementRepository extends JpaRepository<Settlement, Long> ,SettlementCustomRepository{
+public interface SettlementRepository extends JpaRepository<Settlement, Long>, SettlementCustomRepository {
 
     List<Settlement> findAllByBookAndStatus(Book book, Status status);
 }

--- a/src/main/java/com/floney/floney/user/controller/UserController.java
+++ b/src/main/java/com/floney/floney/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.floney.floney.book.dto.request.SaveRecentBookKeyRequest;
 import com.floney.floney.common.dto.Token;
 import com.floney.floney.user.dto.request.EmailAuthenticationRequest;
 import com.floney.floney.user.dto.request.LoginRequest;
+import com.floney.floney.user.dto.request.SignoutRequest;
 import com.floney.floney.user.dto.request.SignupRequest;
 import com.floney.floney.user.dto.request.SubscribeRequest;
 import com.floney.floney.user.dto.security.CustomUserDetails;
@@ -101,8 +102,9 @@ public class UserController {
      * @param accessToken 탈퇴할 유저의 access token
      */
     @GetMapping("/signout")
-    public ResponseEntity<?> signout(@RequestParam String accessToken) {
-        userService.signout(userService.logout(accessToken));
+    public ResponseEntity<?> signout(@RequestParam String accessToken,
+                                     @RequestBody final SignoutRequest request) {
+        userService.signout(userService.logout(accessToken), request);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/com/floney/floney/user/dto/constant/SignoutType.java
+++ b/src/main/java/com/floney/floney/user/dto/constant/SignoutType.java
@@ -1,0 +1,17 @@
+package com.floney.floney.user.dto.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SignoutType {
+
+    OTHER("기타"),
+    NOT_KNOW_HOW_TO_USE("플로니를 어떻게 사용하는지 모르겠어요"),
+    EXPENSIVE("구독료가 비싸요"),
+    NOT_USE_OFTEN("자주 사용하지 않게 돼요"),
+    WILL_SIGNUP_AGAIN("다시 가입할 거예요");
+
+    private final String value;
+}

--- a/src/main/java/com/floney/floney/user/dto/constant/SignoutType.java
+++ b/src/main/java/com/floney/floney/user/dto/constant/SignoutType.java
@@ -1,10 +1,11 @@
 package com.floney.floney.user.dto.constant;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SignoutType {
 
     OTHER("기타"),

--- a/src/main/java/com/floney/floney/user/dto/request/SignoutRequest.java
+++ b/src/main/java/com/floney/floney/user/dto/request/SignoutRequest.java
@@ -1,0 +1,18 @@
+package com.floney.floney.user.dto.request;
+
+import com.floney.floney.user.dto.constant.SignoutType;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class SignoutRequest {
+
+    @NotNull
+    private SignoutType type;
+    private String value;
+}

--- a/src/main/java/com/floney/floney/user/dto/request/SignoutRequest.java
+++ b/src/main/java/com/floney/floney/user/dto/request/SignoutRequest.java
@@ -1,5 +1,6 @@
 package com.floney.floney.user.dto.request;
 
+import com.floney.floney.common.exception.user.SignoutOtherReasonEmptyException;
 import com.floney.floney.user.dto.constant.SignoutType;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -14,5 +15,11 @@ public class SignoutRequest {
 
     @NotNull
     private SignoutType type;
-    private String value;
+    private String reason;
+
+    public void validateReasonNotEmpty() {
+        if (reason == null || reason.isBlank()) {
+            throw new SignoutOtherReasonEmptyException();
+        }
+    }
 }

--- a/src/main/java/com/floney/floney/user/entity/SignoutOtherReason.java
+++ b/src/main/java/com/floney/floney/user/entity/SignoutOtherReason.java
@@ -1,0 +1,27 @@
+package com.floney.floney.user.entity;
+
+import com.floney.floney.common.entity.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignoutOtherReason extends BaseEntity {
+
+    @Lob
+    @Column(nullable = false)
+    private String reason;
+}

--- a/src/main/java/com/floney/floney/user/entity/SignoutOtherReason.java
+++ b/src/main/java/com/floney/floney/user/entity/SignoutOtherReason.java
@@ -3,7 +3,6 @@ package com.floney.floney.user.entity;
 import com.floney.floney.common.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.Lob;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,7 +20,12 @@ import org.hibernate.annotations.DynamicUpdate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignoutOtherReason extends BaseEntity {
 
-    @Lob
     @Column(nullable = false)
     private String reason;
+
+    public static SignoutOtherReason from(final String reason) {
+        return SignoutOtherReason.builder()
+                .reason(reason)
+                .build();
+    }
 }

--- a/src/main/java/com/floney/floney/user/entity/SignoutReason.java
+++ b/src/main/java/com/floney/floney/user/entity/SignoutReason.java
@@ -1,0 +1,34 @@
+package com.floney.floney.user.entity;
+
+import com.floney.floney.common.entity.BaseEntity;
+import com.floney.floney.user.dto.constant.SignoutType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignoutReason extends BaseEntity {
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, unique = true, updatable = false)
+    private SignoutType reasonType;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Long count;
+}

--- a/src/main/java/com/floney/floney/user/entity/SignoutReason.java
+++ b/src/main/java/com/floney/floney/user/entity/SignoutReason.java
@@ -11,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -29,6 +28,5 @@ public class SignoutReason extends BaseEntity {
     private SignoutType reasonType;
 
     @Column(nullable = false)
-    @ColumnDefault("0")
     private Long count;
 }

--- a/src/main/java/com/floney/floney/user/repository/SignoutOtherReasonRepository.java
+++ b/src/main/java/com/floney/floney/user/repository/SignoutOtherReasonRepository.java
@@ -1,0 +1,9 @@
+package com.floney.floney.user.repository;
+
+import com.floney.floney.user.entity.SignoutOtherReason;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SignoutOtherReasonRepository extends JpaRepository<SignoutOtherReason, Long> {
+}

--- a/src/main/java/com/floney/floney/user/repository/SignoutReasonCustomRepository.java
+++ b/src/main/java/com/floney/floney/user/repository/SignoutReasonCustomRepository.java
@@ -1,0 +1,8 @@
+package com.floney.floney.user.repository;
+
+import com.floney.floney.user.dto.constant.SignoutType;
+
+public interface SignoutReasonCustomRepository {
+
+    void increaseCount(final SignoutType signoutType);
+}

--- a/src/main/java/com/floney/floney/user/repository/SignoutReasonCustomRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/user/repository/SignoutReasonCustomRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.floney.floney.user.repository;
+
+import static com.floney.floney.user.entity.QSignoutReason.signoutReason;
+
+import com.floney.floney.user.dto.constant.SignoutType;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SignoutReasonCustomRepositoryImpl implements SignoutReasonCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    @Transactional
+    public void increaseCount(final SignoutType signoutType) {
+        jpaQueryFactory.update(signoutReason)
+                .set(signoutReason.count, signoutReason.count.add(1))
+                .where(signoutReason.reasonType.eq(signoutType))
+                .execute();
+    }
+}

--- a/src/main/java/com/floney/floney/user/repository/SignoutReasonRepository.java
+++ b/src/main/java/com/floney/floney/user/repository/SignoutReasonRepository.java
@@ -1,0 +1,13 @@
+package com.floney.floney.user.repository;
+
+import com.floney.floney.user.dto.constant.SignoutType;
+import com.floney.floney.user.entity.SignoutReason;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SignoutReasonRepository extends JpaRepository<SignoutReason, Long>, SignoutReasonCustomRepository {
+
+    Optional<SignoutReason> findByReasonType(final SignoutType reasonType);
+}

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -11,7 +11,6 @@ import com.floney.floney.common.dto.Token;
 import com.floney.floney.common.exception.user.CodeNotFoundException;
 import com.floney.floney.common.exception.user.CodeNotSameException;
 import com.floney.floney.common.exception.user.PasswordSameException;
-import com.floney.floney.common.exception.user.SignoutOtherReasonEmptyException;
 import com.floney.floney.common.exception.user.UserFoundException;
 import com.floney.floney.common.exception.user.UserNotFoundException;
 import com.floney.floney.common.util.JwtProvider;
@@ -118,10 +117,8 @@ public class UserService {
     }
 
     private void addSignoutOtherReason(final SignoutRequest request) {
-        if(request.getValue() == null || request.getValue().isBlank()) {
-            throw new SignoutOtherReasonEmptyException();
-        }
-        final SignoutOtherReason signoutOtherReason = SignoutOtherReason.from(request.getValue());
+        request.validateReasonNotEmpty();
+        final SignoutOtherReason signoutOtherReason = SignoutOtherReason.from(request.getReason());
         signoutOtherReasonRepository.save(signoutOtherReason);
     }
 

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.floney.floney.common.dto.Token;
 import com.floney.floney.common.exception.user.CodeNotFoundException;
 import com.floney.floney.common.exception.user.CodeNotSameException;
 import com.floney.floney.common.exception.user.PasswordSameException;
+import com.floney.floney.common.exception.user.SignoutOtherReasonEmptyException;
 import com.floney.floney.common.exception.user.UserFoundException;
 import com.floney.floney.common.exception.user.UserNotFoundException;
 import com.floney.floney.common.util.JwtProvider;
@@ -117,6 +118,9 @@ public class UserService {
     }
 
     private void addSignoutOtherReason(final SignoutRequest request) {
+        if(request.getValue() == null || request.getValue().isBlank()) {
+            throw new SignoutOtherReasonEmptyException();
+        }
         final SignoutOtherReason signoutOtherReason = SignoutOtherReason.from(request.getValue());
         signoutOtherReasonRepository.save(signoutOtherReason);
     }

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -16,13 +16,18 @@ import com.floney.floney.common.exception.user.UserNotFoundException;
 import com.floney.floney.common.util.JwtProvider;
 import com.floney.floney.common.util.MailProvider;
 import com.floney.floney.common.util.RedisProvider;
+import com.floney.floney.user.dto.constant.SignoutType;
 import com.floney.floney.user.dto.request.EmailAuthenticationRequest;
 import com.floney.floney.user.dto.request.LoginRequest;
+import com.floney.floney.user.dto.request.SignoutRequest;
 import com.floney.floney.user.dto.request.SignupRequest;
 import com.floney.floney.user.dto.response.MyPageResponse;
 import com.floney.floney.user.dto.response.UserResponse;
 import com.floney.floney.user.dto.security.CustomUserDetails;
+import com.floney.floney.user.entity.SignoutOtherReason;
 import com.floney.floney.user.entity.User;
+import com.floney.floney.user.repository.SignoutOtherReasonRepository;
+import com.floney.floney.user.repository.SignoutReasonRepository;
 import com.floney.floney.user.repository.UserRepository;
 import io.jsonwebtoken.MalformedJwtException;
 import java.util.List;
@@ -50,6 +55,8 @@ public class UserService {
     private final MailProvider mailProvider;
     private final BookUserRepository bookUserRepository;
     private final BookService bookService;
+    private final SignoutReasonRepository signoutReasonRepository;
+    private final SignoutOtherReasonRepository signoutOtherReasonRepository;
 
     @Transactional
     public Token login(final LoginRequest request) {
@@ -91,11 +98,27 @@ public class UserService {
     }
 
     @Transactional
-    public void signout(String email) {
+    public void signout(final String email, final SignoutRequest request) {
         User user = findUserByEmail(email);
         deleteAllBookLinesAndAccountBy(user);
+        addSignoutReason(request);
         // TODO: 유저 엔티티 삭제
         userRepository.save(user);
+    }
+
+    private void addSignoutReason(final SignoutRequest request) {
+        final SignoutType requestType = request.getType();
+
+        if (SignoutType.OTHER.equals(requestType)) {
+            addSignoutOtherReason(request);
+        }
+
+        signoutReasonRepository.increaseCount(requestType);
+    }
+
+    private void addSignoutOtherReason(final SignoutRequest request) {
+        final SignoutOtherReason signoutOtherReason = SignoutOtherReason.from(request.getValue());
+        signoutOtherReasonRepository.save(signoutOtherReason);
     }
 
     public Token reissueToken(Token token) {

--- a/src/test/java/com/floney/floney/user/controller/UserControllerTest.java
+++ b/src/test/java/com/floney/floney/user/controller/UserControllerTest.java
@@ -130,5 +130,4 @@ class UserControllerTest {
                 .andExpect(status().is4xxClientError())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
     }
-
 }

--- a/src/test/java/com/floney/floney/user/repository/SignoutReasonRepositoryTest.java
+++ b/src/test/java/com/floney/floney/user/repository/SignoutReasonRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.floney.floney.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.floney.floney.config.TestConfig;
+import com.floney.floney.user.dto.constant.SignoutType;
+import com.floney.floney.user.entity.SignoutReason;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestConfig.class)
+public class SignoutReasonRepositoryTest {
+
+    @Autowired
+    private SignoutReasonRepository signoutReasonRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void init() {
+        for (final SignoutType signoutType : SignoutType.values()) {
+            final SignoutReason signoutReason = SignoutReason.builder()
+                    .reasonType(signoutType)
+                    .count(0L)
+                    .build();
+            signoutReasonRepository.save(signoutReason);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(SignoutType.class)
+    @DisplayName("탈퇴 사유의 count를 하나 증가시키는 데 성공한다")
+    void increaseSignoutReason_success(final SignoutType signoutType) {
+        // when
+        signoutReasonRepository.increaseCount(signoutType);
+        entityManager.clear();
+
+        // then
+        final SignoutReason signoutReason = signoutReasonRepository.findByReasonType(signoutType).orElseThrow();
+        assertThat(signoutReason.getCount()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/floney/floney/user/service/UserServiceTest.java
+++ b/src/test/java/com/floney/floney/user/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.BDDMockito.then;
 import com.floney.floney.book.repository.BookUserRepository;
 import com.floney.floney.common.dto.Token;
 import com.floney.floney.common.exception.user.PasswordSameException;
+import com.floney.floney.common.exception.user.SignoutOtherReasonEmptyException;
 import com.floney.floney.common.exception.user.UserFoundException;
 import com.floney.floney.common.exception.user.UserNotFoundException;
 import com.floney.floney.common.util.JwtProvider;
@@ -34,6 +35,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -156,8 +159,7 @@ class UserServiceTest {
     void signout_success() {
         // given
         User user = UserFixture.createUser();
-        given(userRepository.findByEmail(user.getEmail()))
-                .willReturn(Optional.of(user));
+        given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
         SignoutRequest request = new SignoutRequest(SignoutType.EXPENSIVE, null);
 
         // when
@@ -179,6 +181,21 @@ class UserServiceTest {
         // when & then
         assertThatThrownBy(() -> userService.signout(user.getEmail(), request))
                 .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("회원탈퇴에 실패한다 - 비어있는 기타 탈퇴 사유")
+    void signout_fail_throws_signoutOtherReasonEmptyException(final String value) {
+        // given
+        User user = UserFixture.createUser();
+        given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
+
+        SignoutRequest request = new SignoutRequest(SignoutType.OTHER, value);
+
+        // when & then
+        assertThatThrownBy(() -> userService.signout(user.getEmail(), request))
+                .isInstanceOf(SignoutOtherReasonEmptyException.class);
     }
 
     @Test

--- a/src/test/java/com/floney/floney/user/service/UserServiceTest.java
+++ b/src/test/java/com/floney/floney/user/service/UserServiceTest.java
@@ -19,12 +19,15 @@ import com.floney.floney.common.util.MailProvider;
 import com.floney.floney.common.util.RedisProvider;
 import com.floney.floney.fixture.BookFixture;
 import com.floney.floney.fixture.UserFixture;
+import com.floney.floney.user.dto.constant.SignoutType;
 import com.floney.floney.user.dto.request.LoginRequest;
+import com.floney.floney.user.dto.request.SignoutRequest;
 import com.floney.floney.user.dto.request.SignupRequest;
 import com.floney.floney.user.dto.response.MyPageResponse;
 import com.floney.floney.user.dto.response.UserResponse;
 import com.floney.floney.user.dto.security.CustomUserDetails;
 import com.floney.floney.user.entity.User;
+import com.floney.floney.user.repository.SignoutReasonRepository;
 import com.floney.floney.user.repository.UserRepository;
 import java.util.Collections;
 import java.util.Optional;
@@ -55,6 +58,8 @@ class UserServiceTest {
     private RedisProvider redisProvider;
     @Mock
     private JwtProvider jwtProvider;
+    @Mock
+    private SignoutReasonRepository signoutReasonRepository;
 
     @Test
     @DisplayName("회원가입에 성공한다")
@@ -153,9 +158,10 @@ class UserServiceTest {
         User user = UserFixture.createUser();
         given(userRepository.findByEmail(user.getEmail()))
                 .willReturn(Optional.of(user));
+        SignoutRequest request = new SignoutRequest(SignoutType.EXPENSIVE, null);
 
         // when
-        userService.signout(user.getEmail());
+        userService.signout(user.getEmail(), request);
 
         // then
         // TODO: 탈퇴시 데이터 삭제로 수정
@@ -168,9 +174,11 @@ class UserServiceTest {
         // given
         User user = UserFixture.createUser();
         given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.empty());
+        SignoutRequest request = new SignoutRequest(SignoutType.EXPENSIVE, null);
 
         // when & then
-        assertThatThrownBy(() -> userService.signout(user.getEmail())).isInstanceOf(UserNotFoundException.class);
+        assertThatThrownBy(() -> userService.signout(user.getEmail(), request))
+                .isInstanceOf(UserNotFoundException.class);
     }
 
     @Test


### PR DESCRIPTION
## 📚 이슈 번호
#204

## 📝 데이터베이스 변경 사항
```sql
CREATE TABLE `signout_reason` (
  `id` bigint NOT NULL AUTO_INCREMENT,
  `created_at` datetime(6) NOT NULL,
  `status` varchar(255) NOT NULL,
  `updated_at` datetime(6) NOT NULL,
  `count` bigint NOT NULL DEFAULT '0',
  `reason_type` varchar(255) NOT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `UK_9f1ps6trvqboiwiblcxy8t5cr` (`reason_type`)
) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

CREATE TABLE `signout_other_reason` (
  `id` bigint NOT NULL AUTO_INCREMENT,
  `created_at` datetime(6) NOT NULL,
  `status` varchar(255) NOT NULL,
  `updated_at` datetime(6) NOT NULL,
  `reason` varchar(255) NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

insert into signout_reason (reason_type, status, created_at, updated_at) values ('OTHER', true, now(), now());
insert into signout_reason (reason_type, status, created_at, updated_at) values ('NOT_KNOW_HOW_TO_USE', true, now(), now());
insert into signout_reason (reason_type, status, created_at, updated_at) values ('EXPENSIVE', true, now(), now());
insert into signout_reason (reason_type, status, created_at, updated_at) values ('NOT_USE_OFTEN', true, now(), now());
insert into signout_reason (reason_type, status, created_at, updated_at) values ('WILL_SIGNUP_AGAIN', true, now(), now());
```

## 💬 기타 사항
- 탈퇴 사유는 고정되어 있으므로 데이터베이스에 초기 데이터를 미리 저장하도록 했습니다.
- 
