### PR TITLE
#268 feat: 정산 API에 요청자가 가계부 유저인지 검사하는 로직 추가

### DIFF
--- a/src/main/java/com/floney/floney/settlement/controller/SettlementController.java
+++ b/src/main/java/com/floney/floney/settlement/controller/SettlementController.java
@@ -1,13 +1,16 @@
 package com.floney.floney.settlement.controller;
 
 import com.floney.floney.settlement.dto.request.SettlementRequest;
+import com.floney.floney.settlement.dto.response.SettlementResponse;
 import com.floney.floney.settlement.service.SettlementService;
+import com.floney.floney.user.dto.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,9 +25,10 @@ public class SettlementController {
      * @param request 정산 내역 생성 요청
      * @return 생성한 정산 내역 응답
      */
-    @PostMapping("")
-    public ResponseEntity<?> createSettlement(@RequestBody @Valid SettlementRequest request) {
-        return new ResponseEntity<>(settlementService.create(request), HttpStatus.CREATED);
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SettlementResponse createSettlement(@RequestBody @Valid final SettlementRequest request) {
+        return settlementService.create(request);
     }
 
     /**
@@ -33,9 +37,11 @@ public class SettlementController {
      * @param bookKey 가계부 key
      * @return 정산 내역 리스트
      */
-    @GetMapping("")
-    public ResponseEntity<?> getSettlementsByBook(@RequestParam String bookKey) {
-        return new ResponseEntity<>(settlementService.findAll(bookKey), HttpStatus.OK);
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<SettlementResponse> getSettlementsByBook(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                                         @RequestParam final String bookKey) {
+        return settlementService.findAll(userDetails.getUsername(), bookKey);
     }
 
     /**
@@ -45,7 +51,9 @@ public class SettlementController {
      * @return 요청한 정산 내역 응답
      */
     @GetMapping("/{id}")
-    public ResponseEntity<?> getSettlement(@PathVariable Long id) {
-        return new ResponseEntity<>(settlementService.find(id), HttpStatus.OK);
+    @ResponseStatus(HttpStatus.OK)
+    public SettlementResponse getSettlement(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                            @PathVariable final Long id) {
+        return settlementService.find(userDetails.getUsername(), id);
     }
 }

--- a/src/main/java/com/floney/floney/settlement/service/SettlementService.java
+++ b/src/main/java/com/floney/floney/settlement/service/SettlementService.java
@@ -36,7 +36,8 @@ public class SettlementService {
     private final BookRepository bookRepository;
     private final BookUserRepository bookUserRepository;
 
-    public List<SettlementResponse> findAll(String bookKey) {
+    public List<SettlementResponse> findAll(final String email, final String bookKey) {
+        validateBookUser(bookKey, email);
         final Book book = findBookByBookKey(bookKey);
 
         return findSettlementsOrderByRecentTime(book)
@@ -45,8 +46,9 @@ public class SettlementService {
                 .toList();
     }
 
-    public SettlementResponse find(Long id) {
+    public SettlementResponse find(final String email, final Long id) {
         final Settlement settlement = findSettlementById(id);
+        validateBookUser(settlement.getBook().getBookKey(), email);
         final List<SettlementUser> settlementUsers = findSettlementUsersBySettlement(settlement);
         return SettlementResponse.of(settlement, settlementUsers);
     }


### PR DESCRIPTION
## 📚 이슈 번호
#268

## 📝 데이터베이스 변경 사항
- 없음

## 💬 기타 사항
- 처음에는 인터셉터나 AOP를 사용하려고 했는데, 이게 요청마다 bookKey를 주는 방식이 다르고 & 어떤 API에는 이미 검사하는 메서드가 포함되어 있어서 우선 정산 쪽만 검사 메서드를 추가하는 방식으로 구현했습니다. 추후 리팩토링 or 가계부 쪽 API에도 추가하겠습니다.. 