### PR TITLE
#319 hotfix: 자산 삭제 시 에러 해결

### DIFF
--- a/src/main/java/com/floney/floney/analyze/service/AssetService.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetService.java
@@ -11,7 +11,7 @@ public interface AssetService {
 
     Map<LocalDate, AssetInfo> getAssetInfo(Book book, String date);
 
-    void createAsset(BookLineRequest request, Book book);
+    void addAssetOf(BookLineRequest request, Book book);
 
-    void deleteAsset(Long bookLineId);
+    void subtractAssetOf(Long bookLineId);
 }

--- a/src/main/java/com/floney/floney/analyze/service/AssetService.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetService.java
@@ -1,17 +1,15 @@
 package com.floney.floney.analyze.service;
 
+import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.dto.process.AssetInfo;
 import com.floney.floney.book.dto.request.BookLineRequest;
-import com.floney.floney.book.domain.entity.Book;
-import com.floney.floney.book.domain.entity.BookLine;
 
 import java.time.LocalDate;
 import java.util.Map;
 
 public interface AssetService {
-    Map<LocalDate, AssetInfo> getAssetInfo(Book book, String date);
 
-    void updateAsset(BookLineRequest request, BookLine savedBookLine);
+    Map<LocalDate, AssetInfo> getAssetInfo(Book book, String date);
 
     void createAssetBy(BookLineRequest request, Book book);
 

--- a/src/main/java/com/floney/floney/analyze/service/AssetService.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetService.java
@@ -11,7 +11,7 @@ public interface AssetService {
 
     Map<LocalDate, AssetInfo> getAssetInfo(Book book, String date);
 
-    void createAssetBy(BookLineRequest request, Book book);
+    void createAsset(BookLineRequest request, Book book);
 
     void deleteAsset(Long bookLineId);
 }

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -96,9 +96,9 @@ public class AssetServiceImpl implements AssetService {
         for (int month = 0; month < SAVED_MONTHS; month++) {
             final LocalDate currentMonth = startMonth.plusMonths(month);
 
-            findAssetByDateAndBook(bookLine.getBook(), currentMonth).ifPresent(asset ->
-                    asset.subtract(bookLine.getMoney(), bookLine.getBookLineCategories().get(FLOW).getName())
-            );
+            final Asset asset = findAssetByDateAndBook(bookLine.getBook(), currentMonth)
+                    .orElseThrow(() -> new RuntimeException("자산 데이터가 존재하지 않습니다"));
+            asset.subtract(bookLine.getMoney(), bookLine.getBookLineCategories().get(FLOW).getName());
         }
     }
 

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -37,7 +37,7 @@ public class AssetServiceImpl implements AssetService {
         Map<LocalDate, AssetInfo> initAssets = getInitAssetInfo(book, date);
 
         // 날짜를 key로 하여, 저장된 데이터가 있다면 대체
-        List<Asset> assets = assetRepository.findByDateBetweenAndBookAndStatus(datesDuration.getStartDate(), datesDuration.getEndDate(), book,ACTIVE);
+        List<Asset> assets = assetRepository.findByDateBetweenAndBookAndStatus(datesDuration.getStartDate(), datesDuration.getEndDate(), book, ACTIVE);
         assets.forEach((asset) -> initAssets.replace(asset.getDate(), AssetInfo.of(asset, book)));
 
         return initAssets;
@@ -66,9 +66,8 @@ public class AssetServiceImpl implements AssetService {
     @Override
     @Transactional
     public void createAssetBy(BookLineRequest request, Book book) {
-
         //이체 내역일 경우 자산 포함 X
-        if(Objects.equals(request.getFlow(), BANK.getKind())){
+        if (Objects.equals(request.getFlow(), BANK.getKind())) {
             return;
         }
 
@@ -77,7 +76,7 @@ public class AssetServiceImpl implements AssetService {
 
         // 5년(60개월) 동안의 엔티티 생성
         for (int i = 0; i < FIVE_YEARS; i++) {
-            Optional<Asset> savedAsset = assetRepository.findAssetByDateAndBookAndStatus(targetDate, book,ACTIVE);
+            Optional<Asset> savedAsset = assetRepository.findAssetByDateAndBookAndStatus(targetDate, book, ACTIVE);
 
             if (savedAsset.isEmpty()) {
                 Asset newAsset = Asset.of(request, book, targetDate);
@@ -104,7 +103,7 @@ public class AssetServiceImpl implements AssetService {
 
         // 5년(60개월) 동안의 엔티티 생성
         for (int i = 0; i < FIVE_YEARS; i++) {
-            Optional<Asset> savedAsset = assetRepository.findAssetByDateAndBookAndStatus(targetDate, savedBookLine.getBook(),ACTIVE);
+            Optional<Asset> savedAsset = assetRepository.findAssetByDateAndBookAndStatus(targetDate, savedBookLine.getBook(), ACTIVE);
             savedAsset.ifPresent(asset -> {
                 asset.delete(savedBookLine.getMoney(), savedBookLine.getBookLineCategories().get(FLOW));
                 assets.add(asset);

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -88,7 +88,7 @@ public class AssetServiceImpl implements AssetService {
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteAsset(final Long bookLineId) {
-        final BookLine bookLine = bookLineRepository.findById(bookLineId)
+        final BookLine bookLine = bookLineRepository.findByIdWithCategories(bookLineId)
                 .orElseThrow(NotFoundBookLineException::new);
 
         final LocalDate startMonth = DateFactory.getFirstDayOf(bookLine.getLineDate());

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -61,14 +61,6 @@ public class AssetServiceImpl implements AssetService {
         return initAssets;
     }
 
-    // 가계부 내역 수정시 asset 업데이트
-    @Override
-    @Transactional
-    public void updateAsset(BookLineRequest request, BookLine savedBookLine) {
-        deleteAsset(savedBookLine.getId());
-        createAssetBy(request, savedBookLine.getBook());
-    }
-
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createAssetBy(final BookLineRequest request, final Book book) {
@@ -104,9 +96,9 @@ public class AssetServiceImpl implements AssetService {
         for (int month = 0; month < SAVED_MONTHS; month++) {
             final LocalDate currentMonth = startMonth.plusMonths(month);
 
-            findAssetByDateAndBook(bookLine.getBook(), currentMonth).ifPresent(asset -> {
-                asset.delete(bookLine.getMoney(), bookLine.getBookLineCategories().get(FLOW));
-            });
+            findAssetByDateAndBook(bookLine.getBook(), currentMonth).ifPresent(asset ->
+                    asset.delete(bookLine.getMoney(), bookLine.getBookLineCategories().get(FLOW))
+            );
         }
     }
 

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -82,7 +82,9 @@ public class AssetServiceImpl implements AssetService {
     public void subtractAssetOf(final Long bookLineId) {
         final BookLine bookLine = bookLineRepository.findByIdWithCategories(bookLineId)
                 .orElseThrow(NotFoundBookLineException::new);
-        validateAlreadyIncludedInAsset(bookLine);
+        if (!bookLine.includedInAsset()) {
+            return;
+        }
 
         final LocalDate startMonth = DateFactory.getFirstDayOf(bookLine.getLineDate());
 
@@ -97,12 +99,6 @@ public class AssetServiceImpl implements AssetService {
             return bookLine.getMoney();
         }
         return (-1) * bookLine.getMoney();
-    }
-
-    private void validateAlreadyIncludedInAsset(final BookLine bookLine) {
-        if (!bookLine.includedInAsset()) {
-            throw new RuntimeException("자산에 포함되지 않은 가계부 내역입니다");
-        }
     }
 }
 

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -63,7 +63,7 @@ public class AssetServiceImpl implements AssetService {
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createAsset(final BookLineRequest request, final Book book) {
+    public void addAssetOf(final BookLineRequest request, final Book book) {
         // 이체 내역일 경우 자산 포함 X
         if (BANK.getKind().equals(request.getFlow())) {
             return;
@@ -87,7 +87,7 @@ public class AssetServiceImpl implements AssetService {
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void deleteAsset(final Long bookLineId) {
+    public void subtractAssetOf(final Long bookLineId) {
         final BookLine bookLine = bookLineRepository.findByIdWithCategories(bookLineId)
                 .orElseThrow(NotFoundBookLineException::new);
 

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -97,7 +97,7 @@ public class AssetServiceImpl implements AssetService {
             final LocalDate currentMonth = startMonth.plusMonths(month);
 
             findAssetByDateAndBook(bookLine.getBook(), currentMonth).ifPresent(asset ->
-                    asset.subtract(bookLine.getMoney(), bookLine.getBookLineCategories().get(FLOW))
+                    asset.subtract(bookLine.getMoney(), bookLine.getBookLineCategories().get(FLOW).getName())
             );
         }
     }

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -80,7 +80,7 @@ public class AssetServiceImpl implements AssetService {
                 assetRepository.save(newAsset);
             } else {
                 final Asset asset = savedAsset.get();
-                asset.update(request.getMoney(), request.getFlow());
+                asset.add(request.getMoney(), request.getFlow());
             }
         }
     }
@@ -97,7 +97,7 @@ public class AssetServiceImpl implements AssetService {
             final LocalDate currentMonth = startMonth.plusMonths(month);
 
             findAssetByDateAndBook(bookLine.getBook(), currentMonth).ifPresent(asset ->
-                    asset.delete(bookLine.getMoney(), bookLine.getBookLineCategories().get(FLOW))
+                    asset.subtract(bookLine.getMoney(), bookLine.getBookLineCategories().get(FLOW))
             );
         }
     }

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -63,7 +63,7 @@ public class AssetServiceImpl implements AssetService {
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createAssetBy(final BookLineRequest request, final Book book) {
+    public void createAsset(final BookLineRequest request, final Book book) {
         // 이체 내역일 경우 자산 포함 X
         if (BANK.getKind().equals(request.getFlow())) {
             return;

--- a/src/main/java/com/floney/floney/analyze/service/BookDeletedEventHandler.java
+++ b/src/main/java/com/floney/floney/analyze/service/BookDeletedEventHandler.java
@@ -27,7 +27,7 @@ public class BookDeletedEventHandler {
     public void deleteBookLine(final BookLineDeletedEvent event) {
         final long bookLineId = event.getBookLineId();
         carryOverService.deleteCarryOver(bookLineId);
-        assetService.deleteAsset(bookLineId);
+        assetService.subtractAssetOf(bookLineId);
         categoryService.deleteAllBookLineCategory(bookLineId);
     }
 

--- a/src/main/java/com/floney/floney/book/domain/entity/Asset.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/Asset.java
@@ -10,7 +10,6 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import java.time.LocalDate;
-import java.util.Objects;
 
 import static com.floney.floney.book.dto.constant.AssetType.INCOME;
 import static com.floney.floney.book.dto.constant.AssetType.OUTCOME;
@@ -32,21 +31,18 @@ public class Asset extends BaseEntity {
     private LocalDate date;
 
     public static Asset of(BookLineRequest request, Book book, LocalDate date) {
-        if (Objects.equals(request.getFlow(), OUTCOME.getKind())) {
-            return Asset
-                    .builder()
+        if (OUTCOME.getKind().equals(request.getFlow())) {
+            return Asset.builder()
                     .money(-1 * request.getMoney())
                     .book(book)
                     .date(date)
                     .build();
-        } else {
-            return Asset
-                    .builder()
-                    .money(request.getMoney())
-                    .book(book)
-                    .date(date)
-                    .build();
         }
+        return Asset.builder()
+                .money(request.getMoney())
+                .book(book)
+                .date(date)
+                .build();
     }
 
     public void add(final double money, final String flow) {
@@ -60,18 +56,5 @@ public class Asset extends BaseEntity {
         }
         // TODO: Exception 리팩토링 시 수정
         throw new RuntimeException("이체는 자산에 추가될 수 없습니다");
-    }
-
-    public void subtract(final double money, final String flow) {
-        if (INCOME.getKind().equals(flow)) {
-            this.money -= money;
-            return;
-        }
-        if (OUTCOME.getKind().equals(flow)) {
-            this.money += money;
-            return;
-        }
-        // TODO: Exception 리팩토링 시 수정
-        throw new RuntimeException("이체는 자산에서 감소될 수 없습니다");
     }
 }

--- a/src/main/java/com/floney/floney/book/domain/entity/Asset.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/Asset.java
@@ -2,12 +2,8 @@ package com.floney.floney.book.domain.entity;
 
 import com.floney.floney.book.dto.constant.AssetType;
 import com.floney.floney.book.dto.request.BookLineRequest;
-import com.floney.floney.common.constant.Status;
 import com.floney.floney.common.entity.BaseEntity;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -15,7 +11,6 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 import static com.floney.floney.book.dto.constant.AssetType.OUTCOME;
@@ -24,22 +19,17 @@ import static com.floney.floney.book.dto.constant.AssetType.OUTCOME;
 @Getter
 @DynamicInsert
 @DynamicUpdate
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Asset extends BaseEntity {
+
     private double money;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Book book;
 
     private LocalDate date;
-
-    @Builder
-    private Asset(Long id, LocalDateTime createdAt, LocalDateTime updatedAt, Status status, double money, Book book, LocalDate date) {
-        super(id, createdAt, updatedAt, status);
-        this.money = money;
-        this.book = book;
-        this.date = date;
-    }
 
     public static Asset of(BookLineRequest request, Book book, LocalDate date) {
         if (Objects.equals(request.getFlow(), OUTCOME.getKind())) {

--- a/src/main/java/com/floney/floney/book/domain/entity/Asset.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/Asset.java
@@ -1,6 +1,5 @@
 package com.floney.floney.book.domain.entity;
 
-import com.floney.floney.book.dto.constant.AssetType;
 import com.floney.floney.book.dto.request.BookLineRequest;
 import com.floney.floney.common.entity.BaseEntity;
 import lombok.*;
@@ -13,6 +12,7 @@ import javax.persistence.ManyToOne;
 import java.time.LocalDate;
 import java.util.Objects;
 
+import static com.floney.floney.book.dto.constant.AssetType.INCOME;
 import static com.floney.floney.book.dto.constant.AssetType.OUTCOME;
 
 @Entity
@@ -49,23 +49,29 @@ public class Asset extends BaseEntity {
         }
     }
 
-    public void add(double updateMoney, String flow) {
-        if (Objects.equals(flow, AssetType.INCOME.getKind())) {
-            money += updateMoney;
-        } else {
-            money -= updateMoney;
+    public void add(final double money, final String flow) {
+        if (INCOME.getKind().equals(flow)) {
+            this.money += money;
+            return;
         }
+        if (OUTCOME.getKind().equals(flow)) {
+            this.money -= money;
+            return;
+        }
+        // TODO: Exception 리팩토링 시 수정
+        throw new RuntimeException("이체는 자산에 추가될 수 없습니다");
     }
 
-    public void subtract(double updateMoney, BookLineCategory flow) {
-        // 기존 내역이 수입이였다면, 현 자산에서 감소
-        if (Objects.equals(flow.getName(), AssetType.INCOME.getKind())) {
-            money -= updateMoney;
+    public void subtract(final double money, final String flow) {
+        if (INCOME.getKind().equals(flow)) {
+            this.money -= money;
+            return;
         }
-
-        // 기존 내역이 지출이였다면, 현 자산에 합
-        else if (Objects.equals(flow.getName(), AssetType.OUTCOME.getKind())) {
-            money += updateMoney;
+        if (OUTCOME.getKind().equals(flow)) {
+            this.money += money;
+            return;
         }
+        // TODO: Exception 리팩토링 시 수정
+        throw new RuntimeException("이체는 자산에서 감소될 수 없습니다");
     }
 }

--- a/src/main/java/com/floney/floney/book/domain/entity/Asset.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/Asset.java
@@ -34,22 +34,22 @@ public class Asset extends BaseEntity {
     public static Asset of(BookLineRequest request, Book book, LocalDate date) {
         if (Objects.equals(request.getFlow(), OUTCOME.getKind())) {
             return Asset
-                .builder()
-                .money(-1 * request.getMoney())
-                .book(book)
-                .date(date)
-                .build();
+                    .builder()
+                    .money(-1 * request.getMoney())
+                    .book(book)
+                    .date(date)
+                    .build();
         } else {
             return Asset
-                .builder()
-                .money(request.getMoney())
-                .book(book)
-                .date(date)
-                .build();
+                    .builder()
+                    .money(request.getMoney())
+                    .book(book)
+                    .date(date)
+                    .build();
         }
     }
 
-    public void update(double updateMoney, String flow) {
+    public void add(double updateMoney, String flow) {
         if (Objects.equals(flow, AssetType.INCOME.getKind())) {
             money += updateMoney;
         } else {
@@ -57,7 +57,7 @@ public class Asset extends BaseEntity {
         }
     }
 
-    public void delete(double updateMoney, BookLineCategory flow) {
+    public void subtract(double updateMoney, BookLineCategory flow) {
         // 기존 내역이 수입이였다면, 현 자산에서 감소
         if (Objects.equals(flow.getName(), AssetType.INCOME.getKind())) {
             money -= updateMoney;

--- a/src/main/java/com/floney/floney/book/domain/entity/BookLine.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/BookLine.java
@@ -33,7 +33,7 @@ public class BookLine extends BaseEntity {
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "bookLine")
     @MapKeyEnumerated(EnumType.STRING)
-    private Map<CategoryEnum, BookLineCategory> bookLineCategories = new EnumMap<>(CategoryEnum.class);
+    private final Map<CategoryEnum, BookLineCategory> bookLineCategories = new EnumMap<>(CategoryEnum.class);
 
     @Column(nullable = false)
     private Double money;

--- a/src/main/java/com/floney/floney/book/domain/entity/BookLine.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/BookLine.java
@@ -1,5 +1,6 @@
 package com.floney.floney.book.domain.entity;
 
+import com.floney.floney.book.dto.constant.AssetType;
 import com.floney.floney.book.dto.constant.CategoryEnum;
 import com.floney.floney.book.dto.request.BookLineRequest;
 import com.floney.floney.book.event.BookLineDeletedEvent;
@@ -76,8 +77,12 @@ public class BookLine extends BaseEntity {
         return this.writer.getNickName();
     }
 
-    public void inactive(){
+    public void inactive() {
         Events.raise(new BookLineDeletedEvent(this.getId()));
         this.status = Status.INACTIVE;
+    }
+
+    public boolean includedInAsset() {
+        return !AssetType.BANK.getKind().equals(bookLineCategories.get(CategoryEnum.FLOW).getName());
     }
 }

--- a/src/main/java/com/floney/floney/book/dto/constant/CategoryEnum.java
+++ b/src/main/java/com/floney/floney/book/dto/constant/CategoryEnum.java
@@ -4,14 +4,14 @@ import lombok.Getter;
 
 @Getter
 public enum CategoryEnum {
+
     FLOW("내역"),
     ASSET("자산"),
     FLOW_LINE("내역분류");
-    private String name;
 
-    CategoryEnum(String name) {
+    private final String name;
+
+    CategoryEnum(final String name) {
         this.name = name;
     }
-
-
 }

--- a/src/main/java/com/floney/floney/book/dto/response/BookLineResponse.java
+++ b/src/main/java/com/floney/floney/book/dto/response/BookLineResponse.java
@@ -39,7 +39,7 @@ public class BookLineResponse {
         this.nickname = nickname;
     }
 
-    public static BookLineResponse of(BookLine bookLine) {
+    public static BookLineResponse from(final BookLine bookLine) {
         return BookLineResponse.builder()
                 .money(bookLine.getMoney())
                 .flow(bookLine.getTargetCategory(FLOW))

--- a/src/main/java/com/floney/floney/book/dto/response/BookLineResponse.java
+++ b/src/main/java/com/floney/floney/book/dto/response/BookLineResponse.java
@@ -51,17 +51,4 @@ public class BookLineResponse {
                 .nickname(bookLine.getWriter())
                 .build();
     }
-
-    public static BookLineResponse changeResponse(BookLine bookLine, String writer) {
-        return BookLineResponse.builder()
-                .money(bookLine.getMoney())
-                .flow(bookLine.getTargetCategory(FLOW))
-                .asset(bookLine.getTargetCategory(ASSET))
-                .line(bookLine.getTargetCategory(FLOW_LINE))
-                .lineDate(bookLine.getLineDate())
-                .description(bookLine.getDescription())
-                .except(bookLine.getExceptStatus())
-                .nickname(writer)
-                .build();
-    }
 }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepository.java
@@ -8,6 +8,5 @@ public interface AssetCustomRepository {
 
     void inactiveAllByBook(Book book);
 
-    void
-    updateMoneyByDateAndBook(double money, LocalDate date, Book book);
+    void updateMoneyByDateAndBook(double money, LocalDate date, Book book);
 }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepository.java
@@ -6,7 +6,8 @@ import java.time.LocalDate;
 
 public interface AssetCustomRepository {
 
-    void inActiveAllByBook(Book book);
+    void inactiveAllByBook(Book book);
 
-    void updateMoneyByDateAndBook(double money, LocalDate date, Book book);
+    void
+    updateMoneyByDateAndBook(double money, LocalDate date, Book book);
 }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepository.java
@@ -2,6 +2,11 @@ package com.floney.floney.book.repository.analyze;
 
 import com.floney.floney.book.domain.entity.Book;
 
+import java.time.LocalDate;
+
 public interface AssetCustomRepository {
+
     void inActiveAllByBook(Book book);
+
+    void updateMoneyByDateAndBook(double money, LocalDate date, Book book);
 }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepositoryImpl.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 
 import static com.floney.floney.book.domain.entity.QAsset.asset;
 import static com.floney.floney.common.constant.Status.ACTIVE;
-import static com.floney.floney.common.constant.Status.INACTIVE;
 
 @Repository
 @Transactional(readOnly = true)
@@ -22,10 +21,8 @@ public class AssetCustomRepositoryImpl implements AssetCustomRepository {
 
     @Override
     @Transactional
-    public void inActiveAllByBook(Book book) {
-        jpaQueryFactory.update(asset)
-                .set(asset.status, INACTIVE)
-                .set(asset.updatedAt, LocalDateTime.now())
+    public void inactiveAllByBook(Book book) {
+        jpaQueryFactory.delete(asset)
                 .where(asset.book.eq(book))
                 .execute();
     }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepositoryImpl.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.floney.floney.book.domain.entity.QAsset.asset;
+import static com.floney.floney.common.constant.Status.ACTIVE;
 import static com.floney.floney.common.constant.Status.INACTIVE;
 
 @Repository
@@ -20,11 +22,25 @@ public class AssetCustomRepositoryImpl implements AssetCustomRepository {
 
     @Override
     @Transactional
-    public void inActiveAllByBook(Book book){
+    public void inActiveAllByBook(Book book) {
         jpaQueryFactory.update(asset)
-            .set(asset.status,INACTIVE)
-            .set(asset.updatedAt, LocalDateTime.now())
-            .where(asset.book.eq(book))
-            .execute();
+                .set(asset.status, INACTIVE)
+                .set(asset.updatedAt, LocalDateTime.now())
+                .where(asset.book.eq(book))
+                .execute();
+    }
+
+    @Override
+    @Transactional
+    public void updateMoneyByDateAndBook(final double money, final LocalDate date, final Book book) {
+        jpaQueryFactory.update(asset)
+                .set(asset.money, asset.money.subtract(money))
+                .set(asset.updatedAt, LocalDateTime.now())
+                .where(
+                        asset.book.eq(book),
+                        asset.date.eq(date),
+                        asset.status.eq(ACTIVE)
+                )
+                .execute();
     }
 }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetRepository.java
@@ -4,19 +4,21 @@ import com.floney.floney.book.domain.entity.Asset;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.common.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-import javax.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface AssetRepository extends JpaRepository<Asset, Long>, AssetCustomRepository {
 
-    Optional<Asset> findAssetByDateAndBookAndStatus(LocalDate targetDate, Book book, Status status);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<Asset> findAssetExclusivelyByDateAndBookAndStatus(LocalDate targetDate, Book book, Status status);
-
     List<Asset> findByDateBetweenAndBookAndStatus(LocalDate startDate, LocalDate endDate, Book book, Status status);
+
+    @Modifying
+    @Query(
+            value = "insert into ASSET (date, money, book_id) values (:date, :money, :book) " +
+                    "on duplicate key update money = money + :money, updated_at = now()",
+            nativeQuery = true
+    )
+    void upsertMoneyByDateAndBook(LocalDate date, Book book, double money);
 }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetRepository.java
@@ -4,13 +4,19 @@ import com.floney.floney.book.domain.entity.Asset;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.common.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
+import javax.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface AssetRepository extends JpaRepository<Asset, Long>, AssetCustomRepository {
+
     Optional<Asset> findAssetByDateAndBookAndStatus(LocalDate targetDate, Book book, Status status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Asset> findAssetExclusivelyByDateAndBookAndStatus(LocalDate targetDate, Book book, Status status);
 
     List<Asset> findByDateBetweenAndBookAndStatus(LocalDate startDate, LocalDate endDate, Book book, Status status);
 }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetRepository.java
@@ -9,8 +9,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface AssetRepository extends JpaRepository<Asset, Long> , AssetCustomRepository{
+public interface AssetRepository extends JpaRepository<Asset, Long>, AssetCustomRepository {
     Optional<Asset> findAssetByDateAndBookAndStatus(LocalDate targetDate, Book book, Status status);
 
-    List<Asset> findByDateBetweenAndBookAndStatus(LocalDate startDate, LocalDate endDate,Book book,Status status);
+    List<Asset> findByDateBetweenAndBookAndStatus(LocalDate startDate, LocalDate endDate, Book book, Status status);
 }

--- a/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
@@ -61,7 +61,7 @@ public class BookLineServiceImpl implements BookLineService {
         categoryFactory.saveCategories(savedLine, request);
 
         BookLine newBookLine = bookLineRepository.save(savedLine);
-        return BookLineResponse.of(newBookLine);
+        return BookLineResponse.from(newBookLine);
     }
 
     @Override
@@ -120,7 +120,7 @@ public class BookLineServiceImpl implements BookLineService {
         // 가계부 내역 갱신
         bookLine.update(request);
 
-        return BookLineResponse.of(bookLine);
+        return BookLineResponse.from(bookLine);
     }
 
     @Override

--- a/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.floney.floney.common.constant.Status.ACTIVE;
 import static java.time.LocalDate.parse;
@@ -102,7 +103,8 @@ public class BookLineServiceImpl implements BookLineService {
         final BookLine bookLine = bookLineRepository.findByIdWithCategories(request.getLineId())
                 .orElseThrow(NotFoundBookLineException::new);
         final Book book = findBook(request.getBookKey());
-
+        // TODO: BookLineRequest에 bookKey 삭제 후 아래 메서드 삭제
+        validateBookLineIncludedInBook(bookLine.getBook(), book);
 
         if (bookLine.includedInAsset()) {
             assetService.subtractAssetOf(bookLine.getId());
@@ -129,6 +131,12 @@ public class BookLineServiceImpl implements BookLineService {
         final BookLine savedBookLine = bookLineRepository.findByIdAndStatus(bookLineId, ACTIVE)
                 .orElseThrow(NotFoundBookLineException::new);
         savedBookLine.inactive();
+    }
+
+    private void validateBookLineIncludedInBook(final Book bookOfBookLine, final Book book) {
+        if (!Objects.equals(bookOfBookLine.getId(), book.getId())) {
+            throw new RuntimeException("가계부 내역이 해당 가계부에 속하지 않습니다");
+        }
     }
 
     private BookUser findBookUser(String currentUser, BookLineRequest request) {

--- a/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
@@ -100,10 +100,10 @@ public class BookLineServiceImpl implements BookLineService {
 
     @Override
     @Transactional
-    public BookLineResponse changeLine(BookLineRequest request) {
-        BookLine bookLine = bookLineRepository.findByIdWithCategories(request.getLineId())
+    public BookLineResponse changeLine(final BookLineRequest request) {
+        final BookLine bookLine = bookLineRepository.findByIdWithCategories(request.getLineId())
             .orElseThrow(NotFoundBookLineException::new);
-        Book book = findBook(request.getBookKey());
+        final Book book = findBook(request.getBookKey());
 
         // 이월 여부에 따른 이월 데이터 갱신
         if (book.getCarryOverStatus()) {
@@ -114,10 +114,13 @@ public class BookLineServiceImpl implements BookLineService {
         assetService.deleteAsset(bookLine.getId());
         assetService.createAssetBy(request, book);
 
+        // 카테고리 데이터 갱신
         categoryFactory.changeCategories(bookLine, request);
+
+        // 가계부 내역 갱신
         bookLine.update(request);
-        BookLine savedBookLine = bookLineRepository.save(bookLine);
-        return BookLineResponse.changeResponse(savedBookLine, bookLine.getWriter());
+
+        return BookLineResponse.of(bookLine);
     }
 
     @Override

--- a/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
@@ -54,7 +54,6 @@ public class BookLineServiceImpl implements BookLineService {
             carryOverFactory.createCarryOverByAddBookLine(request, book);
         }
 
-        // 자산 갱신
         assetService.addAssetOf(request, book);
         BookLine requestLine = request.to(findBookUser(currentUser, request), book);
         BookLine savedLine = bookLineRepository.save(requestLine);

--- a/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
@@ -55,7 +55,7 @@ public class BookLineServiceImpl implements BookLineService {
         }
 
         // 자산 갱신
-        assetService.createAssetBy(request, book);
+        assetService.createAsset(request, book);
         BookLine requestLine = request.to(findBookUser(currentUser, request), book);
         BookLine savedLine = bookLineRepository.save(requestLine);
         categoryFactory.saveCategories(savedLine, request);
@@ -112,7 +112,7 @@ public class BookLineServiceImpl implements BookLineService {
 
         // 자산 데이터 갱신
         assetService.deleteAsset(bookLine.getId());
-        assetService.createAssetBy(request, book);
+        assetService.createAsset(request, book);
 
         // 카테고리 데이터 갱신
         categoryFactory.changeCategories(bookLine, request);

--- a/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
@@ -55,7 +55,7 @@ public class BookLineServiceImpl implements BookLineService {
         }
 
         // 자산 갱신
-        assetService.createAsset(request, book);
+        assetService.addAssetOf(request, book);
         BookLine requestLine = request.to(findBookUser(currentUser, request), book);
         BookLine savedLine = bookLineRepository.save(requestLine);
         categoryFactory.saveCategories(savedLine, request);
@@ -70,10 +70,10 @@ public class BookLineServiceImpl implements BookLineService {
         DatesDuration dates = DateFactory.getDateDuration(date);
 
         return MonthLinesResponse.of(
-            date,
-            daysExpense(bookKey, dates),
-            totalExpense(bookKey, dates),
-            carryOverFactory.getCarryOverInfo(book, date)
+                date,
+                daysExpense(bookKey, dates),
+                totalExpense(bookKey, dates),
+                carryOverFactory.getCarryOverInfo(book, date)
         );
     }
 
@@ -85,10 +85,10 @@ public class BookLineServiceImpl implements BookLineService {
         List<TotalExpense> totalExpenses = bookLineRepository.totalExpenseByDay(parse(date), bookKey);
 
         return TotalDayLinesResponse.of(
-            dayLines,
-            totalExpenses,
-            book.getSeeProfile(),
-            carryOverFactory.getCarryOverInfo(book, date)
+                dayLines,
+                totalExpenses,
+                book.getSeeProfile(),
+                carryOverFactory.getCarryOverInfo(book, date)
         );
     }
 
@@ -102,7 +102,7 @@ public class BookLineServiceImpl implements BookLineService {
     @Transactional
     public BookLineResponse changeLine(final BookLineRequest request) {
         final BookLine bookLine = bookLineRepository.findByIdWithCategories(request.getLineId())
-            .orElseThrow(NotFoundBookLineException::new);
+                .orElseThrow(NotFoundBookLineException::new);
         final Book book = findBook(request.getBookKey());
 
         // 이월 여부에 따른 이월 데이터 갱신
@@ -111,8 +111,8 @@ public class BookLineServiceImpl implements BookLineService {
         }
 
         // 자산 데이터 갱신
-        assetService.deleteAsset(bookLine.getId());
-        assetService.createAsset(request, book);
+        assetService.subtractAssetOf(bookLine.getId());
+        assetService.addAssetOf(request, book);
 
         // 카테고리 데이터 갱신
         categoryFactory.changeCategories(bookLine, request);
@@ -127,18 +127,18 @@ public class BookLineServiceImpl implements BookLineService {
     @Transactional
     public void deleteLine(final Long bookLineId) {
         final BookLine savedBookLine = bookLineRepository.findByIdAndStatus(bookLineId, ACTIVE)
-            .orElseThrow(NotFoundBookLineException::new);
+                .orElseThrow(NotFoundBookLineException::new);
         savedBookLine.inactive();
     }
 
     private BookUser findBookUser(String currentUser, BookLineRequest request) {
         return bookUserRepository.findBookUserByKey(currentUser, request.getBookKey())
-            .orElseThrow(() -> new NotFoundBookUserException(request.getBookKey(), currentUser));
+                .orElseThrow(() -> new NotFoundBookUserException(request.getBookKey(), currentUser));
     }
 
     private Book findBook(String bookKey) {
         return bookRepository.findBookByBookKeyAndStatus(bookKey, ACTIVE)
-            .orElseThrow(() -> new NotFoundBookException(bookKey));
+                .orElseThrow(() -> new NotFoundBookException(bookKey));
     }
 
     private List<BookLineExpense> daysExpense(String bookKey, DatesDuration dates) {

--- a/src/main/java/com/floney/floney/book/service/BookServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookServiceImpl.java
@@ -1,16 +1,16 @@
 package com.floney.floney.book.service;
 
 import com.floney.floney.alarm.repository.AlarmRepository;
+import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookLine;
+import com.floney.floney.book.domain.entity.BookUser;
+import com.floney.floney.book.domain.entity.Budget;
+import com.floney.floney.book.domain.entity.category.BookCategory;
 import com.floney.floney.book.dto.process.MyBookInfo;
 import com.floney.floney.book.dto.process.OurBookInfo;
 import com.floney.floney.book.dto.process.OurBookUser;
 import com.floney.floney.book.dto.request.*;
 import com.floney.floney.book.dto.response.*;
-import com.floney.floney.book.domain.entity.Book;
-import com.floney.floney.book.domain.entity.BookUser;
-import com.floney.floney.book.domain.entity.Budget;
-import com.floney.floney.book.domain.entity.category.BookCategory;
 import com.floney.floney.book.repository.BookLineRepository;
 import com.floney.floney.book.repository.BookRepository;
 import com.floney.floney.book.repository.BookUserRepository;
@@ -224,7 +224,7 @@ public class BookServiceImpl implements BookService {
                 .stream()
                 .map(BookCategory::delete)
                 .forEach(categoryRepository::delete);
-        assetRepository.inActiveAllByBook(book);
+        assetRepository.inactiveAllByBook(book);
         settlementRepository.inactiveAllByBookKey(bookKey);
         bookLineRepository.inactiveAllBy(bookKey);
         carryOverRepository.inactiveAllByBookKey(bookKey);
@@ -297,14 +297,14 @@ public class BookServiceImpl implements BookService {
         }
     }
 
-    private void saveAnotherRecentBookKey(User user){
+    private void saveAnotherRecentBookKey(User user) {
         List<MyBookInfo> myBookInfos = bookUserRepository.findMyBookInfos(user);
         myBookInfos.stream()
-            .findFirst()
-            .ifPresentOrElse(
-                bookInfo -> user.saveRecentBookKey(bookInfo.getBookKey()),
-                () -> user.saveRecentBookKey(null)
-            );
+                .findFirst()
+                .ifPresentOrElse(
+                        bookInfo -> user.saveRecentBookKey(bookInfo.getBookKey()),
+                        () -> user.saveRecentBookKey(null)
+                );
     }
 
     private void validateJoinByBookUserCapacity(Book book) {
@@ -330,7 +330,7 @@ public class BookServiceImpl implements BookService {
     private void inactiveAllBy(final BookUser bookUser) {
         alarmRepository.inactiveAllByBookUser(bookUser);
         bookLineRepository.findAllByBookUser(bookUser)
-            .forEach(BookLine::inactive);
+                .forEach(BookLine::inactive);
         bookLineCategoryRepository.inactiveAllByBookUser(bookUser);
     }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `asset`
+(
+    `id`         bigint       NOT NULL AUTO_INCREMENT,
+    `created_at` datetime(6)  NOT NULL DEFAULT now(),
+    `status`     varchar(255) NOT NULL DEFAULT 'ACTIVE',
+    `updated_at` datetime(6)  NOT NULL DEFAULT now(),
+    `date`       date         NOT NULL,
+    `money`      double       NOT NULL,
+    `book_id`    bigint       NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `book_and_date_on_asset` (`book_id`, `date`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/src/test/java/com/floney/floney/book/MonthLineResponseTest.java
+++ b/src/test/java/com/floney/floney/book/MonthLineResponseTest.java
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class MonthLineResponseTest {
@@ -15,7 +14,7 @@ public class MonthLineResponseTest {
     @Test
     @DisplayName("가계부 총내역이 DB에 존재하는 경우 갱신한다")
     void response() {
-        List<BookLineExpense> savedExpense = Arrays.asList(BookLineFixture.createBookLineExpense());
+        List<BookLineExpense> savedExpense = List.of(BookLineFixture.createBookLineExpense());
         List<BookLineExpense> saved = MonthLinesResponse.reflectDB("2023-10-01", savedExpense);
         Assertions.assertThat(saved.get(42)).isEqualTo(savedExpense.get(0));
     }

--- a/src/test/java/com/floney/floney/fixture/BookLineFixture.java
+++ b/src/test/java/com/floney/floney/fixture/BookLineFixture.java
@@ -69,7 +69,7 @@ public class BookLineFixture {
 
     public static BookLineExpense createBookLineExpense() {
         return BookLineExpense.builder()
-                .assetType("수입")
+                .assetType(INCOME)
                 .date(LOCAL_DATE)
                 .money(1000f)
                 .build();

--- a/src/test/java/com/floney/floney/fixture/BookLineFixture.java
+++ b/src/test/java/com/floney/floney/fixture/BookLineFixture.java
@@ -1,10 +1,10 @@
 package com.floney.floney.fixture;
 
-import com.floney.floney.book.dto.process.BookLineExpense;
-import com.floney.floney.book.dto.request.BookLineRequest;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookLine;
 import com.floney.floney.book.domain.entity.BookUser;
+import com.floney.floney.book.dto.process.BookLineExpense;
+import com.floney.floney.book.dto.request.BookLineRequest;
 
 import java.time.LocalDate;
 
@@ -12,65 +12,59 @@ import static com.floney.floney.fixture.BookFixture.BOOK_KEY;
 
 public class BookLineFixture {
 
-    public static final double OUTCOME = 1000.0;
-    public static final double INCOME = 1000.0;
+    public static final String OUTCOME = "지출";
+    public static final String INCOME = "수입";
 
     public static LocalDate LOCAL_DATE = LocalDate.of(2023, 10, 22);
 
-    public static BookLineRequest createOutcomeRequest() {
+    public static BookLineRequest outcomeRequest(final double money) {
         return BookLineRequest.builder()
                 .bookKey(BOOK_KEY)
-                .flow("지출")
+                .flow(OUTCOME)
                 .asset("은행")
                 .line("식비")
-                .money(OUTCOME)
+                .money(money)
                 .build();
     }
 
-    public static BookLineRequest createIncomeRequest() {
+    public static BookLineRequest incomeRequest(final double money) {
         return BookLineRequest.builder()
                 .bookKey(BOOK_KEY)
-                .flow("수입")
+                .flow(INCOME)
                 .asset("은행")
                 .line("월급")
-                .money(OUTCOME)
+                .money(money)
                 .build();
     }
 
     public static BookLine createBookLine(Book book, double money) {
-        BookLine bookline = BookLine.builder()
+        return BookLine.builder()
                 .book(book)
                 .money(money)
                 .lineDate(LOCAL_DATE)
                 .exceptStatus(Boolean.FALSE)
                 .build();
-
-        return bookline;
     }
 
     public static BookLine createBookLineWithWriter(Book book, double money, BookUser writer) {
-        BookLine bookline = BookLine.builder()
+        return BookLine.builder()
                 .book(book)
                 .money(money)
                 .lineDate(LOCAL_DATE)
                 .writer(writer)
                 .exceptStatus(Boolean.FALSE)
                 .build();
-
-        return bookline;
     }
 
 
     public static BookLine createBookLineWith(BookUser user, Book book, double money) {
-        BookLine bookline = BookLine.builder()
+        return BookLine.builder()
                 .book(book)
                 .writer(user)
                 .money(money)
                 .lineDate(LOCAL_DATE)
                 .exceptStatus(Boolean.FALSE)
                 .build();
-
-        return bookline;
     }
 
     public static BookLineExpense createBookLineExpense() {

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -24,6 +24,9 @@ spring:
     port: 0
     host: host
     password: password
+  sql:
+    init:
+      mode: never
 
 jwt:
   token:


### PR DESCRIPTION
## 📚 이슈 번호
#319

## 📝 데이터베이스 변경 사항
- 없음

## 💬 기타 사항
- 에러 원인: 가계부 내역 id & 날짜가 같은 자산 데이터가 예상과 달리 여러 개 생기는 경우가 있었고, 이를 조회할 때 데이터가 하나가 아니라 SQL 에러가 발생함
- 이유는 정확하지 않지만, 자산 생성 or 삭제 코드를 보면 중간에 데이터의 갱신 손실이 일어날 가능성이 있었습니다. 이를 비관적 락을 걸어서 막았습니다. 날짜가 이른 순서대로 락이 걸려서 데드락이 발생할 것 같지는 않은데 어떻게 생각하세요?
