### PR TITLE
#325 fix : 분석 카테고리 조회 시, 이름이 아닌 객체 자체를 쿼리문에 조건으로 지정

### DIFF
--- a/src/main/java/com/floney/floney/analyze/service/AnalyzeServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AnalyzeServiceImpl.java
@@ -8,12 +8,12 @@ import com.floney.floney.analyze.dto.response.AnalyzeResponse;
 import com.floney.floney.analyze.dto.response.AnalyzeResponseByAsset;
 import com.floney.floney.analyze.dto.response.AnalyzeResponseByBudget;
 import com.floney.floney.analyze.dto.response.AnalyzeResponseByCategory;
+import com.floney.floney.book.domain.entity.Book;
+import com.floney.floney.book.domain.entity.Budget;
 import com.floney.floney.book.domain.entity.Category;
 import com.floney.floney.book.domain.entity.category.BookCategory;
 import com.floney.floney.book.dto.process.AssetInfo;
 import com.floney.floney.book.dto.process.DatesDuration;
-import com.floney.floney.book.domain.entity.Book;
-import com.floney.floney.book.domain.entity.Budget;
 import com.floney.floney.book.repository.BookLineRepository;
 import com.floney.floney.book.repository.BookRepository;
 import com.floney.floney.book.repository.analyze.BudgetRepository;
@@ -51,10 +51,10 @@ public class AnalyzeServiceImpl implements AnalyzeService {
         String bookKey = request.getBookKey();
 
         // 부모가 지출 or 수입인 자식 카테고리 조회
-        List<Category> childCategoriesByRoot = getAllChildCategoryByRoot(rootCategory,bookKey);
+        List<Category> childCategoriesByRoot = getAllChildCategoryByRoot(rootCategory, bookKey);
 
         // 카테고리 별, 가계부 내역 합계 조회
-        List<AnalyzeResponseByCategory> analyzeResultByCategory = bookLineRepository.analyzeByCategory(childCategoriesByRoot,duration,bookKey);
+        List<AnalyzeResponseByCategory> analyzeResultByCategory = bookLineRepository.analyzeByCategory(childCategoriesByRoot, duration, bookKey);
 
         double totalMoney = calculateTotalMoney(analyzeResultByCategory);
         double difference = calculateDifference(request, totalMoney);
@@ -86,7 +86,7 @@ public class AnalyzeServiceImpl implements AnalyzeService {
 
         BookAnalyzer bookAnalyzer = new BookAnalyzer(totalExpense);
         Map<LocalDate, AssetInfo> assetInfo = assetFactory.getAssetInfo(savedBook, request.getDate());
-        return bookAnalyzer.analyzeAsset(request.getDate(),savedBook.getAsset(), assetInfo);
+        return bookAnalyzer.analyzeAsset(request.getDate(), savedBook.getAsset(), assetInfo);
     }
 
     private Book findBook(String bookKey) {
@@ -99,9 +99,9 @@ public class AnalyzeServiceImpl implements AnalyzeService {
         return totalMoney - beforeMonthTotal;
     }
 
-    private List<Category> getAllChildCategoryByRoot(Category rootCategory,String bookKey){
+    private List<Category> getAllChildCategoryByRoot(Category rootCategory, String bookKey) {
         List<Category> childCategoriesByRoot = categoryRepository.findAllDefaultChildCategoryByRoot(rootCategory);
-        List<BookCategory> customCategories = categoryRepository.findAllCustomChildCategoryByRootAndRoot(rootCategory,bookKey);
+        List<BookCategory> customCategories = categoryRepository.findAllCustomChildCategoryByRootAndRoot(rootCategory, bookKey);
         childCategoriesByRoot.addAll(customCategories);
         return childCategoriesByRoot;
     }

--- a/src/main/java/com/floney/floney/book/repository/BookCustomRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/BookCustomRepositoryImpl.java
@@ -30,16 +30,16 @@ public class BookCustomRepositoryImpl implements BookCustomRepository {
     @Override
     public Optional<Book> findByBookUserEmailAndBookKey(final String userEmail, final String bookKey) {
         final BookUser bookUser = jpaQueryFactory.selectFrom(QBookUser.bookUser)
-                .innerJoin(QBookUser.bookUser.book, book).fetchJoin()
-                .innerJoin(QBookUser.bookUser.user, user).fetchJoin()
-                .where(
-                        QBookUser.bookUser.status.eq(ACTIVE),
-                        user.email.eq(userEmail),
-                        book.bookKey.eq(bookKey),
-                        user.status.eq(ACTIVE),
-                        book.status.eq(ACTIVE)
-                )
-                .fetchOne();
+            .innerJoin(QBookUser.bookUser.book, book).fetchJoin()
+            .innerJoin(QBookUser.bookUser.user, user).fetchJoin()
+            .where(
+                QBookUser.bookUser.status.eq(ACTIVE),
+                user.email.eq(userEmail),
+                book.bookKey.eq(bookKey),
+                user.status.eq(ACTIVE),
+                book.status.eq(ACTIVE)
+            )
+            .fetchOne();
 
         if (bookUser == null) {
             return Optional.empty();
@@ -50,25 +50,25 @@ public class BookCustomRepositoryImpl implements BookCustomRepository {
     @Override
     public List<BudgetYearResponse> findBudgetByYear(String bookKey, DatesDuration duration) {
         return jpaQueryFactory
-                .select(new QBudgetYearResponse(budget.date, budget.money))
-                .from(budget)
-                .innerJoin(budget.book, book)
-                .where(book.bookKey.eq(bookKey))
-                .where(budget.date.between(duration.getStartDate(), duration.getEndDate()))
-                .fetch();
+            .select(new QBudgetYearResponse(budget.date, budget.money))
+            .from(budget)
+            .innerJoin(budget.book, book)
+            .where(book.bookKey.eq(bookKey))
+            .where(budget.date.between(duration.getStartDate(), duration.getEndDate()))
+            .fetch();
     }
 
     @Override
     public List<Book> findAllByUserEmail(final String userEmail) {
         return jpaQueryFactory.select(book)
-                .from(bookUser)
-                .innerJoin(bookUser.book, book)
-                .innerJoin(bookUser.user, user)
-                .where(
-                        user.email.eq(userEmail),
-                        book.status.eq(ACTIVE),
-                        bookUser.status.eq(ACTIVE)
-                )
-                .fetch();
+            .from(bookUser)
+            .innerJoin(bookUser.book, book)
+            .innerJoin(bookUser.user, user)
+            .where(
+                user.email.eq(userEmail),
+                book.status.eq(ACTIVE),
+                bookUser.status.eq(ACTIVE)
+            )
+            .fetch();
     }
 }

--- a/src/main/java/com/floney/floney/book/repository/BookLineCustomRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/BookLineCustomRepository.java
@@ -4,6 +4,7 @@ import com.floney.floney.analyze.dto.request.AnalyzeByCategoryRequest;
 import com.floney.floney.analyze.dto.request.AnalyzeRequestByAsset;
 import com.floney.floney.analyze.dto.request.AnalyzeRequestByBudget;
 import com.floney.floney.analyze.dto.response.AnalyzeResponseByCategory;
+import com.floney.floney.book.domain.entity.Category;
 import com.floney.floney.book.dto.process.*;
 import com.floney.floney.book.dto.request.AllOutcomesRequest;
 import com.floney.floney.book.domain.entity.Book;
@@ -31,7 +32,7 @@ public interface BookLineCustomRepository {
 
     Double totalExpenseForBeforeMonth(AnalyzeByCategoryRequest request);
 
-    List<AnalyzeResponseByCategory> analyzeByCategory(AnalyzeByCategoryRequest request);
+    List<AnalyzeResponseByCategory> analyzeByCategory(List<Category> childCategories, DatesDuration duration, String bookKey);
 
     Double totalOutcomeMoneyForBudget(AnalyzeRequestByBudget request, DatesDuration duration);
 

--- a/src/main/java/com/floney/floney/book/repository/BookLineRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/BookLineRepositoryImpl.java
@@ -212,18 +212,19 @@ public class BookLineRepositoryImpl implements BookLineCustomRepository {
     public List<AnalyzeResponseByCategory> analyzeByCategory(AnalyzeByCategoryRequest request) {
         DatesDuration datesRequest = DateFactory.getDateDuration(request.getDate());
 
+        // 지출, 수입
         Category targetRoot = jpaQueryFactory.selectFrom(category)
             .where(category.name.eq(request.getRoot()),
                 category.instanceOf(RootCategory.class))
             .fetchOne();
 
-        List<String> children = jpaQueryFactory.select(category.name)
+        List<Category> children = jpaQueryFactory.select(category)
             .from(category)
             .where(category.parent.eq(targetRoot),
                 category.instanceOf(DefaultCategory.class))
             .fetch();
 
-        children.addAll(jpaQueryFactory.select(bookCategory.name)
+        children.addAll(jpaQueryFactory.select(bookCategory)
             .from(bookCategory)
             .innerJoin(bookCategory.parent, category)
             .where(category.eq(targetRoot))
@@ -237,7 +238,7 @@ public class BookLineRepositoryImpl implements BookLineCustomRepository {
             .innerJoin(bookLine.book, book)
             .where(book.bookKey.eq(request.getBookKey()))
             .innerJoin(bookLine.bookLineCategories, bookLineCategory)
-            .where(bookLineCategory.name.in(children), bookLine.status.eq(ACTIVE), bookLineCategory.status.eq(ACTIVE))
+            .where(bookLineCategory.category.in(children), bookLine.status.eq(ACTIVE), bookLineCategory.status.eq(ACTIVE))
             .where(bookLine.lineDate.between(datesRequest.getStartDate(), datesRequest.getEndDate()))
             .groupBy(bookLineCategory.name)
             .fetch();

--- a/src/main/java/com/floney/floney/book/repository/category/CategoryCustomRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/category/CategoryCustomRepository.java
@@ -28,6 +28,10 @@ public interface CategoryCustomRepository {
 
     List<BookCategory> findAllCustomCategory(Book book);
 
+    List<Category> findAllDefaultChildCategoryByRoot(Category root);
+
+    List<BookCategory> findAllCustomChildCategoryByRootAndRoot(Category root, String bookKey);
+
     Optional<Category> findParentCategory(String parentName);
 
     void inactiveAllByBook(Book book);

--- a/src/main/java/com/floney/floney/book/repository/category/CategoryCustomRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/category/CategoryCustomRepositoryImpl.java
@@ -204,6 +204,26 @@ public class CategoryCustomRepositoryImpl implements CategoryCustomRepository {
     }
 
     @Override
+    public List<Category> findAllDefaultChildCategoryByRoot(Category root){
+       return jpaQueryFactory.select(category)
+            .from(category)
+            .where(category.parent.eq(root),
+                category.instanceOf(DefaultCategory.class))
+            .fetch();
+    }
+
+    @Override
+    public List<BookCategory> findAllCustomChildCategoryByRootAndRoot(Category root, String bookKey){
+        return jpaQueryFactory.select(bookCategory)
+            .from(bookCategory)
+            .innerJoin(bookCategory.parent, category)
+            .where(category.eq(root))
+            .innerJoin(bookCategory.book, book)
+            .where(book.bookKey.eq(bookKey))
+            .fetch();
+    }
+
+    @Override
     public Optional<Category> findParentCategory(String parentName) {
         return Optional.ofNullable(jpaQueryFactory.selectFrom(category)
             .where(

--- a/src/test/java/com/floney/floney/book/BookLineRepositoryTest.java
+++ b/src/test/java/com/floney/floney/book/BookLineRepositoryTest.java
@@ -262,7 +262,7 @@ public class BookLineRepositoryTest {
     void analyzeByCategory() {
         BookLine bookLine = bookLineRepository.save(createBookLine(book, 1000));
 
-        // 1. 카테고리 생성
+        // given - 1. 카테고리 생성
         DefaultCategory category = DefaultCategory.builder()
             .name("급여")
             .build();
@@ -273,18 +273,18 @@ public class BookLineRepositoryTest {
             .build();
         DefaultCategory savedCategory2 = categoryRepository.save(category2);
 
-        // 2. 가계부 내역과 급여 카테고리 매핑
+        // given - 2. 가계부 내역과 급여 카테고리 매핑
         BookLineCategory bookLineFlowLineCategory = bookLineCategoryRepository.save(createLineCategory(savedCategory, bookLine));
         bookLine.add(CategoryEnum.FLOW_LINE,bookLineFlowLineCategory);
        bookLineRepository.save(bookLine);
 
-       // 3. 가계부 내역2와 급여 카테고리 매핑
+        // given - 3. 가계부 내역2와 급여 카테고리 매핑
         BookLine bookLine2 = bookLineRepository.save(createBookLine(book, 1000));
         BookLineCategory bookLineFlowLineCategory2 = bookLineCategoryRepository.save(createLineCategory(savedCategory2, bookLine));
         bookLine2.add(CategoryEnum.FLOW_LINE,bookLineFlowLineCategory2);
         bookLineRepository.save(bookLine2);
 
-        // 4. 가계부 내역3과 용돈 카테고리 매핑
+        // given - 4. 가계부 내역3과 용돈 카테고리 매핑
         BookLine bookLine3 = bookLineRepository.save(createBookLine(book, 1000));
         BookLineCategory bookLineFlowLineCategory3 = bookLineCategoryRepository.save(createLineCategory(savedCategory, bookLine));
         bookLine2.add(CategoryEnum.FLOW_LINE,bookLineFlowLineCategory3);
@@ -295,8 +295,10 @@ public class BookLineRepositoryTest {
                      .endDate(LOCAL_DATE.plusDays(1))
                          .build();
 
+        // when
         List<AnalyzeResponseByCategory> responses = bookLineRepository.analyzeByCategory(Arrays.asList(category2,category),datesDuration,book.getBookKey());
 
+        // then
         for (AnalyzeResponseByCategory response : responses) {
             assertThat(response.getCategory())
                 .isIn("급여", "용돈");

--- a/src/test/java/com/floney/floney/book/BookLineRepositoryTest.java
+++ b/src/test/java/com/floney/floney/book/BookLineRepositoryTest.java
@@ -2,12 +2,12 @@ package com.floney.floney.book;
 
 import com.floney.floney.analyze.dto.response.AnalyzeResponseByCategory;
 import com.floney.floney.book.domain.entity.*;
+import com.floney.floney.book.domain.entity.category.BookCategory;
 import com.floney.floney.book.dto.constant.CategoryEnum;
 import com.floney.floney.book.dto.process.BookLineExpense;
 import com.floney.floney.book.dto.process.DatesDuration;
 import com.floney.floney.book.dto.process.TotalExpense;
 import com.floney.floney.book.dto.request.AllOutcomesRequest;
-import com.floney.floney.book.domain.entity.category.BookCategory;
 import com.floney.floney.book.repository.BookLineRepository;
 import com.floney.floney.book.repository.BookRepository;
 import com.floney.floney.book.repository.BookUserRepository;
@@ -238,20 +238,20 @@ public class BookLineRepositoryTest {
         Category savedFlowCategory = categoryRepository.save(flowCategory);
         BookLineCategory savedBookLineCategory = bookLineCategoryRepository.save(createFlowCategory((DefaultCategory) savedFlowCategory, bookLine));
         bookLine.add(CategoryEnum.FLOW, savedBookLineCategory);
-       
+
         DefaultCategory assetCategory = DefaultCategory.builder()
             .name("은행")
             .build();
         Category savedAssetCategory = categoryRepository.save(assetCategory);
         BookLineCategory bookLineAssetCategory = bookLineCategoryRepository.save(createLineCategory((DefaultCategory) savedAssetCategory, bookLine));
-        bookLine.add(CategoryEnum.ASSET,bookLineAssetCategory);
+        bookLine.add(CategoryEnum.ASSET, bookLineAssetCategory);
 
         DefaultCategory flowLineCategory = DefaultCategory.builder()
             .name("급여")
             .build();
         Category savedFlowLineCategory = categoryRepository.save(flowLineCategory);
         BookLineCategory bookLineFlowLineCategory = bookLineCategoryRepository.save(createLineCategory((DefaultCategory) savedFlowLineCategory, bookLine));
-        bookLine.add(CategoryEnum.FLOW_LINE,bookLineFlowLineCategory);
+        bookLine.add(CategoryEnum.FLOW_LINE, bookLineFlowLineCategory);
 
         BookLine savedBookLine = bookLineRepository.save(bookLine);
         assertThat(savedBookLine.getBookLineCategories().size()).isEqualTo(3);
@@ -275,35 +275,46 @@ public class BookLineRepositoryTest {
 
         // given - 2. 가계부 내역과 급여 카테고리 매핑
         BookLineCategory bookLineFlowLineCategory = bookLineCategoryRepository.save(createLineCategory(savedCategory, bookLine));
-        bookLine.add(CategoryEnum.FLOW_LINE,bookLineFlowLineCategory);
-       bookLineRepository.save(bookLine);
+        bookLine.add(CategoryEnum.FLOW_LINE, bookLineFlowLineCategory);
+        bookLineRepository.save(bookLine);
 
         // given - 3. 가계부 내역2와 급여 카테고리 매핑
         BookLine bookLine2 = bookLineRepository.save(createBookLine(book, 1000));
         BookLineCategory bookLineFlowLineCategory2 = bookLineCategoryRepository.save(createLineCategory(savedCategory2, bookLine));
-        bookLine2.add(CategoryEnum.FLOW_LINE,bookLineFlowLineCategory2);
+        bookLine2.add(CategoryEnum.FLOW_LINE, bookLineFlowLineCategory2);
         bookLineRepository.save(bookLine2);
 
         // given - 4. 가계부 내역3과 용돈 카테고리 매핑
         BookLine bookLine3 = bookLineRepository.save(createBookLine(book, 1000));
         BookLineCategory bookLineFlowLineCategory3 = bookLineCategoryRepository.save(createLineCategory(savedCategory, bookLine));
-        bookLine2.add(CategoryEnum.FLOW_LINE,bookLineFlowLineCategory3);
+        bookLine2.add(CategoryEnum.FLOW_LINE, bookLineFlowLineCategory3);
         bookLineRepository.save(bookLine3);
 
         DatesDuration datesDuration = DatesDuration.builder()
-                 .startDate(LOCAL_DATE)
-                     .endDate(LOCAL_DATE.plusDays(1))
-                         .build();
+            .startDate(LOCAL_DATE)
+            .endDate(LOCAL_DATE.plusDays(1))
+            .build();
 
         // when
-        List<AnalyzeResponseByCategory> responses = bookLineRepository.analyzeByCategory(Arrays.asList(category2,category),datesDuration,book.getBookKey());
+        List<AnalyzeResponseByCategory> responses = bookLineRepository.analyzeByCategory(Arrays.asList(category2, category), datesDuration, book.getBookKey());
+
+        List<String> categoryName = Arrays.asList("급여", "용돈");
+        List<Double> analyzeResult = Arrays.asList(2000.0, 1000.0);
 
         // then
         for (AnalyzeResponseByCategory response : responses) {
-            assertThat(response.getCategory())
-                .isIn("급여", "용돈");
-            assertThat((response.getMoney())).isIn(2000.0, 1000.0);
+            assertThat(response)
+                .extracting(AnalyzeResponseByCategory::getCategory)
+                .usingRecursiveComparison()
+                .isIn(categoryName);
+
+            assertThat(response)
+                .extracting(AnalyzeResponseByCategory::getMoney)
+                .usingRecursiveComparison()
+                .isIn(analyzeResult);
+
         }
+
     }
 }
 


### PR DESCRIPTION
## 📚 이슈 번호
#325

## 📝 데이터베이스 변경 사항


## 💬 기타 사항
[에러 원인]
- 카테고리의 '이름'으로 쿼리문에서 조건을 걸다보니, 기타 와 미분류 처럼 부모가 다르지만 자식끼리 이름이 같은 경우, 중복된 값이 잡히고 있었습니다.

[해결 방안]
따라서, name이 아닌, entity자체로 비교하는 것으로 변경하였습니다


- 테스트 코드를 짜다가, 카테고리 리팩토링이 들어가고 있는 것으로 알아서, 포함시키지 않았습니다
