### PR TITLE
#318 fix : 관리자 권한으로 빌드 실행

### DIFF
--- a/script/start.sh
+++ b/script/start.sh
@@ -13,7 +13,7 @@ echo "[ $TIME_NOW ] Copy file $JAR_FILE to project root" >> $DEPLOY_LOG
 cp $PROJECT_ROOT/build/libs/*.jar $JAR_FILE
 
 echo "[ $TIME_NOW ] Run java application : $JAR_FILE" >> $DEPLOY_LOG
-nohup java -jar $JAR_FILE --spring.profiles.active=develop > $APP_LOG 2> $ERROR_LOG &
+sudo nohup java -jar $JAR_FILE --spring.profiles.active=develop > $APP_LOG 2> $ERROR_LOG &
 
 CURRENT_PID=$(pgrep -f $JAR_FILE)
 echo "[ $TIME_NOW ] Application running PID : $CURRENT_PID" >> $DEPLOY_LOG


### PR DESCRIPTION
## 📚 이슈 번호
#318

## 📝 데이터베이스 변경 사항
- 내용

## 💬 기타 사항

[로그 파일이 생기지 않은 원인 파악]
- 수동으로 빌드 할 때 항상 잘 된 이유 -> 제가 빌드를 실행하는 경로는 Floney_server 폴더 내입니다. 
![image](https://github.com/Floney-2023/Floney-Server/assets/90383376/bb0e1c6a-8705-4490-a35c-c5cc1236d254)

- Ec2에서 github action이 파일을 실행하는 경로는 root입니다. 하지만 root에서는 폴더를 생성하기 위해서는 관리자 권한이 필요합니다

1. root 위치에서 start.sh에 기재된 명령어를 치고 수동으로 빌드 시 다음과 같은 에러가 납니다
2. root경로에서 mkdir 명령어를 작성하면 permission denied가 발생합니다.(이 이유 때문에 예전에 mkdir이 수행 안된듯 합니다)
3. 따라서 sudo 권한을 주어 명령어를 실행해야 정상적으로 로그 파일이 생깁니다.
![image](https://github.com/Floney-2023/Floney-Server/assets/90383376/07892e8e-734a-4350-8a8f-c024d401c317)
