### PR TITLE
#335 hotfix: 자산 upsert 쿼리에서 테이블 이름을 소문자로 변경

### DIFF
--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetRepository.java
@@ -16,7 +16,7 @@ public interface AssetRepository extends JpaRepository<Asset, Long>, AssetCustom
 
     @Modifying
     @Query(
-            value = "insert into ASSET (date, money, book_id) values (:date, :money, :book) " +
+            value = "insert into asset (date, money, book_id) values (:date, :money, :book) " +
                     "on duplicate key update money = money + :money, updated_at = now()",
             nativeQuery = true
     )


### PR DESCRIPTION
## 📌 개요

자산 upsert 쿼리에서 테이블 이름을 소문자로 변경

## ✅ 개발 내용

- EC2 운영체제에서 에러가 나지 않기 위해 대문자로 되어있던 테이블 이름을 소문자로 변경
