### PR TITLE
#339 hotfix: OUTCOME인 내역은 자산을 (-)로 추가하도록 수정

### DIFF
--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.floney.floney.book.dto.constant.AssetType.BANK;
+import static com.floney.floney.book.dto.constant.AssetType.OUTCOME;
 import static com.floney.floney.book.dto.constant.CategoryEnum.FLOW;
 import static com.floney.floney.common.constant.Status.ACTIVE;
 
@@ -73,7 +74,7 @@ public class AssetServiceImpl implements AssetService {
 
         for (int month = 0; month < SAVED_MONTHS; month++) {
             final LocalDate currentMonth = startMonth.plusMonths(month);
-            assetRepository.upsertMoneyByDateAndBook(currentMonth, book, request.getMoney());
+            assetRepository.upsertMoneyByDateAndBook(currentMonth, book, getMoneyToAdd(request));
         }
     }
 
@@ -92,6 +93,13 @@ public class AssetServiceImpl implements AssetService {
             final LocalDate currentMonth = startMonth.plusMonths(month);
             assetRepository.updateMoneyByDateAndBook(getMoneyToSubtract(bookLine), currentMonth, bookLine.getBook());
         }
+    }
+
+    private double getMoneyToAdd(final BookLineRequest request) {
+        if (OUTCOME.getKind().equals(request.getFlow())) {
+            return (-1) * request.getMoney();
+        }
+        return request.getMoney();
     }
 
     private double getMoneyToSubtract(final BookLine bookLine) {


### PR DESCRIPTION
## 📌 개요

내역 추가/수정에 따른 자산 추가 시 지출(OUTCOME)이면 (-)로 추가하도록 수정

## ✅ 개발 내용

- 지출(OUTCOME)이면 (-)로 자산 데이터가 갱신/생성 되도록 수정
