### PR TITLE
#334 hotfix: subtractAssetOf 메서드에서 부호가 반대로 연산되던 문제 수정

### DIFF
--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -3,7 +3,6 @@ package com.floney.floney.analyze.service;
 import com.floney.floney.book.domain.entity.Asset;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookLine;
-import com.floney.floney.book.dto.constant.AssetType;
 import com.floney.floney.book.dto.process.AssetInfo;
 import com.floney.floney.book.dto.process.DatesDuration;
 import com.floney.floney.book.dto.request.BookLineRequest;
@@ -103,7 +102,7 @@ public class AssetServiceImpl implements AssetService {
     }
 
     private double getMoney(final BookLine bookLine) {
-        if (bookLine.getTargetCategory(FLOW).equals(AssetType.OUTCOME.getKind())) {
+        if (bookLine.getTargetCategory(FLOW).equals(OUTCOME.getKind())) {
             return (-1) * bookLine.getMoney();
         }
         return bookLine.getMoney();

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -74,7 +74,7 @@ public class AssetServiceImpl implements AssetService {
 
         for (int month = 0; month < SAVED_MONTHS; month++) {
             final LocalDate currentMonth = startMonth.plusMonths(month);
-            assetRepository.upsertMoneyByDateAndBook(currentMonth, book, getMoneyToAdd(request));
+            assetRepository.upsertMoneyByDateAndBook(currentMonth, book, getMoney(request));
         }
     }
 
@@ -91,22 +91,22 @@ public class AssetServiceImpl implements AssetService {
 
         for (int month = 0; month < SAVED_MONTHS; month++) {
             final LocalDate currentMonth = startMonth.plusMonths(month);
-            assetRepository.updateMoneyByDateAndBook(getMoneyToSubtract(bookLine), currentMonth, bookLine.getBook());
+            assetRepository.subtractMoneyByDateAndBook(getMoney(bookLine), currentMonth, bookLine.getBook());
         }
     }
 
-    private double getMoneyToAdd(final BookLineRequest request) {
+    private double getMoney(final BookLineRequest request) {
         if (OUTCOME.getKind().equals(request.getFlow())) {
             return (-1) * request.getMoney();
         }
         return request.getMoney();
     }
 
-    private double getMoneyToSubtract(final BookLine bookLine) {
+    private double getMoney(final BookLine bookLine) {
         if (bookLine.getTargetCategory(FLOW).equals(AssetType.OUTCOME.getKind())) {
-            return bookLine.getMoney();
+            return (-1) * bookLine.getMoney();
         }
-        return (-1) * bookLine.getMoney();
+        return bookLine.getMoney();
     }
 }
 

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepository.java
@@ -8,5 +8,5 @@ public interface AssetCustomRepository {
 
     void inactiveAllByBook(Book book);
 
-    void updateMoneyByDateAndBook(double money, LocalDate date, Book book);
+    void subtractMoneyByDateAndBook(double money, LocalDate date, Book book);
 }

--- a/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/AssetCustomRepositoryImpl.java
@@ -29,7 +29,7 @@ public class AssetCustomRepositoryImpl implements AssetCustomRepository {
 
     @Override
     @Transactional
-    public void updateMoneyByDateAndBook(final double money, final LocalDate date, final Book book) {
+    public void subtractMoneyByDateAndBook(final double money, final LocalDate date, final Book book) {
         jpaQueryFactory.update(asset)
                 .set(asset.money, asset.money.subtract(money))
                 .set(asset.updatedAt, LocalDateTime.now())

--- a/src/main/java/com/floney/floney/user/service/AuthenticationService.java
+++ b/src/main/java/com/floney/floney/user/service/AuthenticationService.java
@@ -37,14 +37,17 @@ public class AuthenticationService {
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Token login(final LoginRequest request) {
+        // mysql read + write : 평균 120ms
+        // mysql read + redis write : 평균 120ms ...
         try {
             final User user = findUserByEmail(request.getEmail());
             validatePasswordMatches(request, user.getPassword());
 
-            user.login();
-            userRepository.save(user);
+            redisProvider.set("*", "*", 1);
+//            user.login();
+//            userRepository.save(user);
 
             return jwtProvider.generateToken(user.getEmail());
         } catch (BadCredentialsException exception) {

--- a/src/main/java/com/floney/floney/user/service/AuthenticationService.java
+++ b/src/main/java/com/floney/floney/user/service/AuthenticationService.java
@@ -37,17 +37,14 @@ public class AuthenticationService {
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Token login(final LoginRequest request) {
-        // mysql read + write : 평균 120ms
-        // mysql read + redis write : 평균 120ms ...
         try {
             final User user = findUserByEmail(request.getEmail());
             validatePasswordMatches(request, user.getPassword());
 
-            redisProvider.set("*", "*", 1);
-//            user.login();
-//            userRepository.save(user);
+            user.login();
+            userRepository.save(user);
 
             return jwtProvider.generateToken(user.getEmail());
         } catch (BadCredentialsException exception) {


### PR DESCRIPTION
## 📌 개요

자산 제외 시 가계부 내역 유형(수입/지출)에 따라 부호가 반대로 연산되던 현상을 수정

## ✅ 개발 내용

- `subtractMoneyByDateAndBook` 로 쿼리 메서드 이름 변경
- 자산 추가 & 제외 시 필요한 부호 통일
