### PR TITLE
#342 hotfix : 카테고리 중복 생성 방지 검사 추가

### DIFF
--- a/src/main/java/com/floney/floney/book/service/category/CategoryServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/category/CategoryServiceImpl.java
@@ -12,6 +12,7 @@ import com.floney.floney.book.repository.category.BookLineCategoryRepository;
 import com.floney.floney.book.repository.category.CategoryRepository;
 import com.floney.floney.book.service.BookLineService;
 import com.floney.floney.common.constant.Status;
+import com.floney.floney.common.exception.book.AlreadyExistException;
 import com.floney.floney.common.exception.book.NotFoundBookException;
 import com.floney.floney.common.exception.book.NotFoundCategoryException;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,12 @@ public class CategoryServiceImpl implements CategoryService {
             parent = categoryRepository.findParentCategory(request.getParent())
                 .orElseThrow(() -> new NotFoundCategoryException(request.getParent()));
         }
+
+        // 같은 이름으로 카테고리 생성 방지
+        categoryRepository.findCustomTarget(parent, request.getBookKey(), request.getName()).ifPresent(saved -> {
+            throw new AlreadyExistException(request.getName());
+        });
+
         BookCategory newCategory = categoryRepository.save(request.of(parent, findBook(request.getBookKey())));
         return CreateCategoryResponse.of(newCategory);
     }
@@ -70,7 +77,7 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     @Transactional
-    public void deleteAllBookLineCategory(long bookLineId){
+    public void deleteAllBookLineCategory(long bookLineId) {
         bookLineCategoryRepository.inactiveAllByBookLineId(bookLineId);
     }
 

--- a/src/main/java/com/floney/floney/common/exception/book/AlreadyExistException.java
+++ b/src/main/java/com/floney/floney/common/exception/book/AlreadyExistException.java
@@ -1,0 +1,15 @@
+package com.floney.floney.common.exception.book;
+
+import com.floney.floney.common.exception.common.ErrorType;
+import lombok.Getter;
+
+@Getter
+public class AlreadyExistException extends RuntimeException {
+    private final ErrorType errorType;
+    private final String target;
+
+    public AlreadyExistException(String target) {
+        this.errorType = ErrorType.ALREADY_EXIST;
+        this.target = target;
+    }
+}

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
@@ -37,103 +37,103 @@ public class ErrorControllerAdvice {
         logger.warn("이미 존재하는 유저: [{}]", exception.getEmail());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(body);
+            .body(body);
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     protected ResponseEntity<ErrorResponse> notFoundUser(UserNotFoundException exception) {
         logger.warn("저장되지 않은 유저 정보: [{}]", exception.getUsername());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(MailAddressException.class)
     protected ResponseEntity<ErrorResponse> notValidMailAddress(MailAddressException exception) {
         logger.warn("유효하지 않은 메일 주소: [{}]", exception.getEmail());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(MailException.class)
     protected ResponseEntity<ErrorResponse> failToSendMail(MailException exception) {
         logger.error("메일 전송 오류 \n [ERROR_MSG] : {} \n [ERROR STACK] : {}", exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(ErrorType.FAIL_TO_SEND_MAIL));
+            .body(ErrorResponse.of(ErrorType.FAIL_TO_SEND_MAIL));
     }
 
     @ExceptionHandler(ExpiredJwtException.class)
     protected ResponseEntity<ErrorResponse> expiredJwtToken(ExpiredJwtException exception) {
         logger.warn("만료된 토큰");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(ErrorType.EXPIRED_JWT_TOKEN));
+            .body(ErrorResponse.of(ErrorType.EXPIRED_JWT_TOKEN));
     }
 
     @ExceptionHandler(JwtException.class)
     protected ResponseEntity<ErrorResponse> invalidJwtToken(JwtException exception) {
         logger.warn("유효하지 않은 JWT 토큰: {}", exception.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(ErrorType.INVALID_JWT_TOKEN));
+            .body(ErrorResponse.of(ErrorType.INVALID_JWT_TOKEN));
     }
 
     @ExceptionHandler(BadCredentialsException.class)
     protected ResponseEntity<ErrorResponse> invalidLogin(BadCredentialsException exception) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(ErrorType.INVALID_LOGIN));
+            .body(ErrorResponse.of(ErrorType.INVALID_LOGIN));
     }
 
     @ExceptionHandler(EmailNotFoundException.class)
     protected ResponseEntity<ErrorResponse> emailNotFound(EmailNotFoundException exception) {
         logger.warn("이메일({}) 찾기 실패", exception.getEmail());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(CodeNotSameException.class)
     protected ResponseEntity<ErrorResponse> invalidCode(CodeNotSameException exception) {
         logger.debug("일치하지 않는 이메일 인증 코드: [{}], [{}]", exception.getCode(), exception.getAnotherCode());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(CodeNotFoundException.class)
     protected ResponseEntity<ErrorResponse> notExistCode(CodeNotFoundException exception) {
         logger.debug("이메일[{}] 인증 시간 만료", exception.getEmail());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(OAuthResponseException.class)
     protected ResponseEntity<ErrorResponse> badOAuthResponse(OAuthResponseException exception) {
         logger.error("외부 로그인 서버에서 빈 응답을 받음 \n [ERROR_MSG] : {} \n [ERROR STACK] : {}", exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(OAuthTokenNotValidException.class)
     protected ResponseEntity<ErrorResponse> invalidOAuthToken(OAuthTokenNotValidException exception) {
         logger.warn("외부 로그인 서버에서 잘못된 토큰으로 인한 인증 실패");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(SignoutOtherReasonEmptyException.class)
     protected ResponseEntity<ErrorResponse> signoutOtherReasonEmpty(SignoutOtherReasonEmptyException exception) {
         logger.warn("회원 탈퇴 요청에서 value가 비어있음");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotEmailUserException.class)
     protected ResponseEntity<ErrorResponse> notEmailUser(NotEmailUserException exception) {
         logger.warn("이메일 유저가 아니라 간편 유저({})임", exception.getProvider());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(PasswordSameException.class)
     protected ResponseEntity<ErrorResponse> samePassword(PasswordSameException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     // BOOK
@@ -141,86 +141,93 @@ public class ErrorControllerAdvice {
     protected ResponseEntity<ErrorResponse> notFoundBook(NotFoundBookException exception) {
         logger.warn("가계부 키 [{}] 가계부 {}", exception.getRequestKey(), ErrorType.NOT_FOUND_BOOK.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(MaxMemberException.class)
     protected ResponseEntity<ErrorResponse> maxMember(MaxMemberException exception) {
         logger.warn("가계부 키 [{}] 가계부 {} => 현 인원[{}]", exception.getBookKey(),
-                ErrorType.MAX_MEMBER.getMessage(),
-                exception.getMemberCount());
+            ErrorType.MAX_MEMBER.getMessage(),
+            exception.getMemberCount());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotFoundCategoryException.class)
     protected ResponseEntity<ErrorResponse> notFoundCategory(NotFoundCategoryException exception) {
         logger.warn("[{}] {}", exception.getCategoryName(), ErrorType.NOT_FOUND_CATEGORY.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(CannotDeleteBookException.class)
     protected ResponseEntity<ErrorResponse> cannotDeleteBook(CannotDeleteBookException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotFoundBookUserException.class)
     protected ResponseEntity<ErrorResponse> notFoundUser(NotFoundBookUserException exception) {
         logger.warn("가계부 키 [{}] 에서 [{}]와 일치하는 {}",
-                exception.getBookKey(),
-                exception.getRequestUser(),
-                ErrorType.NOT_FOUND_BOOK_USER.getMessage());
+            exception.getBookKey(),
+            exception.getRequestUser(),
+            ErrorType.NOT_FOUND_BOOK_USER.getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotFoundBookLineException.class)
     protected ResponseEntity<ErrorResponse> notFoundLine(NotFoundBookLineException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(ExcelMakingException.class)
     protected ResponseEntity<ErrorResponse> notFoundLine(ExcelMakingException exception) {
         logger.error("엑셀 오류 발생 [ERROR_MSG] : {} \n [ERROR_STACK] : {} \n ", exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(LimitRequestException.class)
     protected ResponseEntity<ErrorResponse> limitOfService(LimitRequestException exception) {
         logger.warn(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NoAuthorityException.class)
     protected ResponseEntity<ErrorResponse> notOwner(NoAuthorityException exception) {
         logger.warn("{} : 가계부 방장 [{}] , 요청자 [{}]",
-                exception.getOwner(),
-                ErrorType.NO_AUTHORITY.getMessage(),
-                exception.getRequestUser());
+            exception.getOwner(),
+            ErrorType.NO_AUTHORITY.getMessage(),
+            exception.getRequestUser());
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(AlreadyJoinException.class)
     protected ResponseEntity<ErrorResponse> joinException(AlreadyJoinException exception) {
         logger.warn("{}는 {} \n [ERROR_MSG] : {} \n  [ERROR_STACK] : {}", exception.getUserEmail(), ErrorType.ALREADY_JOIN.getMessage(), exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotFoundAlarmException.class)
     protected ResponseEntity<ErrorResponse> alarmException(NotFoundAlarmException exception) {
         logger.error("{} id = {} \n [ERROR_MSG] : {} \n [ERROR_STACK] : {}", ErrorType.NOT_FOUND_ALARM.getMessage(), exception.getRequestKey(), exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
+    }
+
+    @ExceptionHandler(AlreadyExistException.class)
+    protected ResponseEntity<ErrorResponse> alreadyExistException(AlreadyExistException exception) {
+        logger.error("{} id = {} \n [ERROR_MSG] : {} \n [ERROR_STACK] : {}", ErrorType.ALREADY_EXIST.getMessage(), exception.getTarget(), exception.getMessage(), exception.getStackTrace());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     // SETTLEMENT
@@ -228,21 +235,21 @@ public class ErrorControllerAdvice {
     protected ResponseEntity<ErrorResponse> settlementNotFoundException(SettlementNotFoundException exception) {
         logger.warn("settlement id [{}]의 정산 내역이 존재하지 않음", exception.getSettlementId());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(OutcomeUserNotFoundException.class)
     protected ResponseEntity<ErrorResponse> outcomeUserNotFoundException(OutcomeUserNotFoundException exception) {
         logger.warn("Request Body에서 지출 내역의 유저가 유저 목록에 존재하지 않음");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     // ALARM
     @ExceptionHandler(GoogleAccessTokenGenerateException.class)
     protected ResponseEntity<ErrorResponse> failToGenerateGoogleAccessTokenException(GoogleAccessTokenGenerateException exception) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     // OTHER
@@ -252,7 +259,7 @@ public class ErrorControllerAdvice {
         logger.warn("요청 body의 @Valid 에러 - [{}] : {} ", exception.getTarget(), message);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(ErrorType.REQUEST_BODY_ERROR, message));
+            .body(ErrorResponse.of(ErrorType.REQUEST_BODY_ERROR, message));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
@@ -260,14 +267,14 @@ public class ErrorControllerAdvice {
         logger.warn("요청 파라미터 없음 : {} ", exception.getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(ErrorType.REQUEST_PARAMETER_ERROR, exception.getMessage()));
+            .body(ErrorResponse.of(ErrorType.REQUEST_PARAMETER_ERROR, exception.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> otherException(Exception exception) {
         loggingError(exception);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(ErrorType.SERVER_ERROR));
+            .body(ErrorResponse.of(ErrorType.SERVER_ERROR));
     }
 
     private void loggingError(final Exception exception) {

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorType.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorType.java
@@ -41,6 +41,7 @@ public enum ErrorType {
     ALREADY_JOIN("B008", "이미 존재하는 가계부 유저입니다"),
     FAIL_TO_CREATE_EXCEL("B009", "엑셀 파일을 생성하는 중 오류가 발생했습니다"),
     NOT_FOUND_ALARM("B010", "알람 내역을 찾을 수 없습니다"),
+    ALREADY_EXIST("B011", "이미 존재하는 데이터입니다"),
 
     LIMIT("S002", "제공하지 않는 서비스입니다"),
 


### PR DESCRIPTION
## 📌 개요

카테고리 중복을 방지하기 위한 검사 메서드 추가

## ✅ 개발 내용

다음과 같이 중복된 이름의 카테고리를 추가하면, 에러가 반환되게끔 수정했습니다.
![image](https://github.com/Floney-2023/Floney-Server/assets/90383376/82a42d7a-7931-44d8-bfc1-bb6765548f3b)

기존 오기입 된 카테고리는 운영서버 DB에서 수동으로 지울 예정입니다.