### PR TITLE
#318 fix : 빌드 시 권한 777 부여

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -2,7 +2,7 @@ version: 0.0
 os: linux
 
 files:
-  - source:  /
+  - source: /
     destination: /home/ubuntu/Floney-Server
     overwrite: yes
 
@@ -13,7 +13,7 @@ permissions:
     pattern: "**"
     owner: ubuntu
     group: ubuntu
-    mode: 755
+    mode: 777
 
 hooks:
   AfterInstall:

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `asset`
+CREATE TABLE asset
 (
     `id`         bigint       NOT NULL AUTO_INCREMENT,
     `created_at` datetime(6)  NOT NULL DEFAULT now(),


### PR DESCRIPTION
## 📌 개요

Code Deploy 빌드 시 권한 777 부여

## ✅ 개발 내용

755 권한으로 인해, 다른 사용자는 해당 파일에 권한이 없어 로그 파일이 안생기나? 라는 가정을 통해 777권한을 줘보게 되었습니다..
