### PR TITLE
#366 feat: 비밀번호 변경 제한 추가

### DIFF
--- a/src/main/java/com/floney/floney/common/config/RedisConfig.java
+++ b/src/main/java/com/floney/floney/common/config/RedisConfig.java
@@ -23,10 +23,9 @@ public class RedisConfig {
 
     @Bean
     public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        final RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
 
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
         return redisTemplate;

--- a/src/main/java/com/floney/floney/common/config/RedisConfig.java
+++ b/src/main/java/com/floney/floney/common/config/RedisConfig.java
@@ -10,23 +10,24 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+
     @Value("${spring.redis.host}")
-    private String redisHost;
+    private String host;
 
     @Value("${spring.redis.port}")
-    private int redisPort;
+    private int port;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisHost, redisPort);
+        return new LettuceConnectionFactory(host, port);
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
+    public RedisTemplate<String, String> redisTemplate(final RedisConnectionFactory redisConnectionFactory) {
         final RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
 
         redisTemplate.setDefaultSerializer(new StringRedisSerializer());
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
 
         return redisTemplate;
     }

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
@@ -296,6 +296,7 @@ public class ErrorControllerAdvice {
         }
 
         logger.error(stringBuilder.toString());
+        exception.printStackTrace();
     }
 }
 

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
@@ -296,7 +296,6 @@ public class ErrorControllerAdvice {
         }
 
         logger.error(stringBuilder.toString());
-        exception.printStackTrace();
     }
 }
 

--- a/src/main/java/com/floney/floney/common/util/RedisProvider.java
+++ b/src/main/java/com/floney/floney/common/util/RedisProvider.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
+// TODO: 해당 클래스 삭제
 @Component
 @RequiredArgsConstructor
 public class RedisProvider {
@@ -14,10 +15,10 @@ public class RedisProvider {
 
     public void set(String key, String value, long timeout) {
         redisTemplate.opsForValue().set(
-                key,
-                value,
-                timeout,
-                TimeUnit.MILLISECONDS
+            key,
+            value,
+            timeout,
+            TimeUnit.MILLISECONDS
         );
     }
 

--- a/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
+++ b/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
@@ -25,6 +25,10 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
         validatePasswordInHistory(password, email);
 
         listOperations.rightPush(email, password);
+        removeExceedingPasswords(email);
+    }
+
+    private void removeExceedingPasswords(final String email) {
         while (listOperations.size(email) > MAX_HISTORY_SIZE) {
             listOperations.leftPop(email);
         }

--- a/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
+++ b/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
@@ -2,7 +2,6 @@ package com.floney.floney.user.infrastructure;
 
 import com.floney.floney.common.exception.user.PasswordSameException;
 import com.floney.floney.user.service.PasswordHistoryManager;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.ListOperations;
@@ -10,11 +9,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Resource;
 import java.util.List;
 
 @Component
-@RequiredArgsConstructor
 public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass().getSimpleName());
@@ -24,9 +21,15 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
     private static final int MAX_HISTORY_SIZE = 5;
 
     private final RedisTemplate<String, String> redisTemplate;
-    @Resource(name = "redisTemplate")
-    private ListOperations<String, String> listOperations;
+    private final ListOperations<String, String> listOperations;
     private final PasswordEncoder passwordEncoder;
+
+    private PasswordHistoryManagerImpl(final RedisTemplate<String, String> redisTemplate,
+                                       final PasswordEncoder passwordEncoder) {
+        this.redisTemplate = redisTemplate;
+        this.listOperations = redisTemplate.opsForList();
+        this.passwordEncoder = passwordEncoder;
+    }
 
     @Override
     public void addPassword(final String password, final long userId) {

--- a/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
+++ b/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
@@ -58,11 +58,14 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
 
     private void validateCanAddPassword(final String password, final String key) {
         final List<String> history = listOperations.range(key, START_INDEX, END_INDEX);
-        for (final String encodedPassword : history) {
-            if (passwordEncoder.matches(password, encodedPassword)) {
-                throw new PasswordSameException();
-            }
+        if (isPasswordInHistory(password, history)) {
+            throw new PasswordSameException();
         }
+    }
+
+    private boolean isPasswordInHistory(final String password, final List<String> history) {
+        return history.stream()
+            .anyMatch(encodedPassword -> passwordEncoder.matches(password, encodedPassword));
     }
 
     private void checkHistorySize(final String key) {

--- a/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
+++ b/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
@@ -18,7 +18,8 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
-    private static final String KEY_PASSWORD_HISTORY = "user:passwords:";
+    private static final String KEY_USER = "user:";
+    private static final String KEY_PASSWORDS = ":passwords";
     private static final int MAX_HISTORY_SIZE = 5;
 
     @Resource(name = "redisTemplate")
@@ -26,9 +27,9 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public void addPassword(final String password, final String email) {
+    public void addPassword(final String password, final long userId) {
         final String encodedPassword = passwordEncoder.encode(password);
-        final String key = email.concat(KEY_PASSWORD_HISTORY);
+        final String key = KEY_USER + userId + KEY_PASSWORDS;
         checkHistorySize(key);
         validateCanAddPassword(password, key);
 

--- a/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
+++ b/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
@@ -19,6 +19,8 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
     private static final String KEY_USER = "user:";
     private static final String KEY_PASSWORDS = ":passwords";
     private static final int MAX_HISTORY_SIZE = 5;
+    private static final int START_INDEX = 0;
+    private static final int END_INDEX = -1;
 
     private final RedisTemplate<String, String> redisTemplate;
     private final ListOperations<String, String> listOperations;
@@ -55,7 +57,7 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
     }
 
     private void validateCanAddPassword(final String password, final String key) {
-        final List<String> history = listOperations.range(key, 0, -1);
+        final List<String> history = listOperations.range(key, START_INDEX, END_INDEX);
         for (final String encodedPassword : history) {
             if (passwordEncoder.matches(password, encodedPassword)) {
                 throw new PasswordSameException();

--- a/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
+++ b/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
@@ -1,0 +1,44 @@
+package com.floney.floney.user.infrastructure;
+
+import com.floney.floney.common.exception.user.PasswordSameException;
+import com.floney.floney.user.service.PasswordHistoryManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+@Component
+public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass().getSimpleName());
+
+    private static final int MAX_HISTORY_SIZE = 5;
+
+    @Resource(name = "redisTemplate")
+    private ListOperations<String, String> listOperations;
+
+    @Override
+    public void addPassword(final String password, final String email) {
+        checkHistorySize(email);
+        validatePasswordInHistory(password, email);
+
+        listOperations.rightPush(email, password);
+        while (listOperations.size(email) > MAX_HISTORY_SIZE) {
+            listOperations.leftPop(email);
+        }
+    }
+
+    private void validatePasswordInHistory(final String password, final String email) {
+        if (listOperations.indexOf(email, password) != null) {
+            throw new PasswordSameException();
+        }
+    }
+
+    private void checkHistorySize(final String email) {
+        if (listOperations.size(email) > MAX_HISTORY_SIZE) {
+            logger.error("이전 비밀번호 내역이 {}개를 초과", MAX_HISTORY_SIZE);
+        }
+    }
+}

--- a/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
+++ b/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
@@ -65,7 +65,7 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
 
     private void checkHistorySize(final String key) {
         if (listOperations.size(key) > MAX_HISTORY_SIZE) {
-            logger.error("이전 비밀번호 내역이 {}개를 초과", MAX_HISTORY_SIZE);
+            logger.warn("Redis에서 이전 비밀번호 내역이 {}개를 초과", MAX_HISTORY_SIZE);
         }
     }
 }

--- a/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
+++ b/src/main/java/com/floney/floney/user/infrastructure/PasswordHistoryManagerImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,7 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
     private static final String KEY_PASSWORDS = ":passwords";
     private static final int MAX_HISTORY_SIZE = 5;
 
+    private final RedisTemplate<String, String> redisTemplate;
     @Resource(name = "redisTemplate")
     private ListOperations<String, String> listOperations;
     private final PasswordEncoder passwordEncoder;
@@ -35,6 +37,12 @@ public class PasswordHistoryManagerImpl implements PasswordHistoryManager {
 
         listOperations.rightPush(key, encodedPassword);
         removeExceedingPasswords(key);
+    }
+
+    @Override
+    public void deleteHistory(final long userId) {
+        final String key = KEY_USER + userId + KEY_PASSWORDS;
+        redisTemplate.unlink(key);
     }
 
     private void removeExceedingPasswords(final String key) {

--- a/src/main/java/com/floney/floney/user/service/PasswordHistoryManager.java
+++ b/src/main/java/com/floney/floney/user/service/PasswordHistoryManager.java
@@ -1,0 +1,6 @@
+package com.floney.floney.user.service;
+
+public interface PasswordHistoryManager {
+
+    void addPassword(String password, String email);
+}

--- a/src/main/java/com/floney/floney/user/service/PasswordHistoryManager.java
+++ b/src/main/java/com/floney/floney/user/service/PasswordHistoryManager.java
@@ -2,5 +2,5 @@ package com.floney.floney.user.service;
 
 public interface PasswordHistoryManager {
 
-    void addPassword(String password, String email);
+    void addPassword(String password, long userId);
 }

--- a/src/main/java/com/floney/floney/user/service/PasswordHistoryManager.java
+++ b/src/main/java/com/floney/floney/user/service/PasswordHistoryManager.java
@@ -3,4 +3,6 @@ package com.floney.floney.user.service;
 public interface PasswordHistoryManager {
 
     void addPassword(String password, long userId);
+
+    void deleteHistory(long userId);
 }

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -53,6 +53,7 @@ public class UserService {
     private final SignoutReasonRepository signoutReasonRepository;
     private final SignoutOtherReasonRepository signoutOtherReasonRepository;
     private final MailProvider mailProvider;
+    private final PasswordHistoryManager passwordHistoryManager;
 
     public LoginRequest signup(SignupRequest request) {
         validateUserExistByEmail(request.getEmail());
@@ -169,6 +170,7 @@ public class UserService {
 
     private void updatePassword(String newPassword, User user) {
         validatePasswordNotSame(newPassword, user);
+        passwordHistoryManager.addPassword(newPassword, user.getId());
         user.updatePassword(newPassword);
         user.encodePassword(passwordEncoder);
     }
@@ -189,7 +191,7 @@ public class UserService {
 
     private User findUserByEmail(final String email) {
         return userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserNotFoundException(email));
+            .orElseThrow(() -> new UserNotFoundException(email));
     }
 
     private void validateUserExistByEmail(String email) {

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -74,6 +74,7 @@ public class UserService {
 
         user.signout();
         addSignoutReason(request);
+        passwordHistoryManager.deleteHistory(user.getId());
 
         return SignoutResponse.of(deletedBookKeys, notDeletedBookKeys);
     }

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -60,6 +60,7 @@ public class UserService {
         final User user = request.to();
         user.encodePassword(passwordEncoder);
         userRepository.save(user);
+        passwordHistoryManager.addPassword(user.getPassword(), user.getId());
         return request.toLoginRequest();
     }
 

--- a/src/test/java/com/floney/floney/acceptance/config/IntegrationTestExecutionListener.java
+++ b/src/test/java/com/floney/floney/acceptance/config/IntegrationTestExecutionListener.java
@@ -4,6 +4,8 @@ import io.restassured.RestAssured;
 import io.restassured.config.EncoderConfig;
 import io.restassured.config.LogConfig;
 import io.restassured.http.ContentType;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
@@ -27,5 +29,15 @@ public class IntegrationTestExecutionListener extends AbstractTestExecutionListe
                 .enablePrettyPrinting(true))
             .encoderConfig(EncoderConfig.encoderConfig()
                 .defaultCharsetForContentType(StandardCharsets.UTF_8.name(), ContentType.ANY));
+    }
+
+    @Override
+    public void afterTestMethod(final TestContext testContext) throws Exception {
+        final RedisTemplate<String, String> redisTemplate = (RedisTemplate<String, String>) testContext.getApplicationContext().getBean("redisTemplate");
+        final RedisConnectionFactory connectionFactory = redisTemplate.getConnectionFactory();
+        if (connectionFactory == null) {
+            throw new IllegalStateException("Redis Connection Factory가 존재하지 않습니다.");
+        }
+        connectionFactory.getConnection().flushAll();
     }
 }

--- a/src/test/java/com/floney/floney/fixture/UserFixture.java
+++ b/src/test/java/com/floney/floney/fixture/UserFixture.java
@@ -1,47 +1,48 @@
 package com.floney.floney.fixture;
 
-import static com.floney.floney.fixture.BookFixture.EMAIL;
-
 import com.floney.floney.user.dto.constant.Provider;
 import com.floney.floney.user.entity.User;
+
 import java.time.LocalDateTime;
+
+import static com.floney.floney.fixture.BookFixture.EMAIL;
 
 public class UserFixture {
 
     public static User emailUser() {
         return User.builder()
-                .nickname("floney")
-                .email(EMAIL)
-                .password("password")
-                .profileImg("user_default")
-                .lastAdTime(LocalDateTime.of(2023, 4, 15, 12, 30, 45))
-                .provider(Provider.EMAIL)
-                .receiveMarketing(true)
-                .build();
+            .nickname("floney")
+            .email(EMAIL)
+            .password("password")
+            .profileImg("user_default")
+            .lastAdTime(LocalDateTime.of(2023, 4, 15, 12, 30, 45))
+            .provider(Provider.EMAIL)
+            .receiveMarketing(true)
+            .build();
     }
 
     public static User emailUserWithEmail(final String email) {
         return User.builder()
-                .nickname("floney")
-                .email(email)
-                .password("password")
-                .profileImg("user_default")
-                .lastAdTime(LocalDateTime.now())
-                .provider(Provider.EMAIL)
-                .receiveMarketing(true)
-                .build();
+            .nickname("floney")
+            .email(email)
+            .password("password")
+            .profileImg("user_default")
+            .lastAdTime(LocalDateTime.now())
+            .provider(Provider.EMAIL)
+            .receiveMarketing(true)
+            .build();
     }
 
     public static User kakaoUser() {
         return User.builder()
-                .nickname("floney")
-                .email("floney2@naver.com")
-                .password("password")
-                .profileImg("user_default")
-                .lastAdTime(LocalDateTime.of(2023, 4, 15, 12, 30, 45))
-                .provider(Provider.KAKAO)
-                .receiveMarketing(false)
-                .build();
+            .nickname("floney")
+            .email("floney2@naver.com")
+            .password("password")
+            .profileImg("user_default")
+            .lastAdTime(LocalDateTime.of(2023, 4, 15, 12, 30, 45))
+            .provider(Provider.KAKAO)
+            .receiveMarketing(false)
+            .build();
     }
 
 }

--- a/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
+++ b/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
@@ -116,4 +116,32 @@ class PasswordHistoryManagerTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("deleteHistory 메서드에서")
+    class Describe_DeleteHistory {
+
+        @Nested
+        @DisplayName("회원이 비밀번호 내역을 가지고 있는 경우")
+        class Context_UserHasPasswordHistory {
+
+            final long userId = 1;
+            final String key = KEY_USER + userId + KEY_PASSWORDS;
+
+            @BeforeEach
+            public void init() {
+                passwordHistoryManager.addPassword("a", userId);
+                passwordHistoryManager.addPassword("b", userId);
+                passwordHistoryManager.addPassword("c", userId);
+            }
+
+            @Test
+            @DisplayName("비밀번호 내역을 지운다.")
+            void it_succeeds() {
+                passwordHistoryManager.deleteHistory(userId);
+
+                assertThat(redisTemplate.hasKey(key)).isFalse();
+            }
+        }
+    }
 }

--- a/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
+++ b/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
@@ -58,7 +58,7 @@ class PasswordHistoryManagerTest {
 
             @Test
             @DisplayName("현재 비밀번호를 내역에 추가한다.")
-            void it_returns_nothing() {
+            void it_succeeds() {
                 passwordHistoryManager.addPassword(password, userId);
 
                 final String encodedPassword = listOperations.rightPop(key);
@@ -82,7 +82,7 @@ class PasswordHistoryManagerTest {
 
             @Test
             @DisplayName("현재 비밀번호를 내역에 추가한다.")
-            void it_returns_nothing() {
+            void it_succeeds() {
                 passwordHistoryManager.addPassword(password, userId);
 
                 final String encodedPassword = listOperations.rightPop(key);

--- a/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
+++ b/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
@@ -1,0 +1,119 @@
+package com.floney.floney.user.service;
+
+import com.floney.floney.common.exception.user.PasswordSameException;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.annotation.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PasswordValidator 테스트")
+@SpringBootTest
+class PasswordHistoryManagerTest {
+
+    private static final String KEY_USER = "user:";
+    private static final String KEY_PASSWORDS = ":passwords";
+
+    @Autowired
+    private PasswordHistoryManager passwordHistoryManager;
+
+    @Resource(name = "redisTemplate")
+    private ListOperations<String, String> listOperations;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Nested
+    @DisplayName("addPassword 메서드에서")
+    class Describe_AddPassword {
+
+        @Nested
+        @DisplayName("이전 비밀번호 내역에 현재 비밀번호가 포함되지 않는 경우")
+        class Context_PasswordNotIncludedInHistory {
+
+            final String password = "new";
+            final long userId = 1;
+            final String key = KEY_USER + userId + KEY_PASSWORDS;
+
+            @BeforeEach
+            public void init() {
+                passwordHistoryManager.addPassword("a", userId);
+                passwordHistoryManager.addPassword("b", userId);
+                passwordHistoryManager.addPassword("c", userId);
+            }
+
+            @AfterEach
+            public void reset() {
+                redisTemplate.delete(key);
+            }
+
+            @Test
+            @DisplayName("현재 비밀번호를 내역에 추가한다.")
+            void it_returns_nothing() {
+                passwordHistoryManager.addPassword(password, userId);
+
+                final String encodedPassword = listOperations.rightPop(key);
+                assertThat(passwordEncoder.matches(password, encodedPassword)).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("이전 비밀번호 내역이 비어있는 경우")
+        class Context_EmptyPasswordHistory {
+
+            final String password = "new";
+            final long userId = 1;
+            final String key = KEY_USER + userId + KEY_PASSWORDS;
+
+
+            @AfterEach
+            public void reset() {
+                redisTemplate.delete(key);
+            }
+
+            @Test
+            @DisplayName("현재 비밀번호를 내역에 추가한다.")
+            void it_returns_nothing() {
+                passwordHistoryManager.addPassword(password, userId);
+
+                final String encodedPassword = listOperations.rightPop(key);
+                assertThat(passwordEncoder.matches(password, encodedPassword)).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("이전 비밀번호 내역에 현재 비밀번호가 포함되는 경우")
+        class Context_PasswordIncludedInHistory {
+
+            final String password = "new";
+            final long userId = 1;
+            final String key = KEY_USER + userId + KEY_PASSWORDS;
+
+            @BeforeEach
+            public void init() {
+                passwordHistoryManager.addPassword(password, userId);
+            }
+
+            @AfterEach
+            public void reset() {
+                redisTemplate.delete(key);
+            }
+
+            @Test
+            @DisplayName("에러가 발생한다.")
+            void it_returns_error() {
+                assertThatThrownBy(() -> passwordHistoryManager.addPassword(password, userId))
+                    .isInstanceOf(PasswordSameException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/com/floney/floney/user/service/UserServiceTest.java
+++ b/src/test/java/com/floney/floney/user/service/UserServiceTest.java
@@ -1,11 +1,5 @@
 package com.floney.floney.user.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.anyString;
-import static org.mockito.BDDMockito.given;
-
 import com.floney.floney.book.repository.BookRepository;
 import com.floney.floney.book.repository.BookUserRepository;
 import com.floney.floney.common.exception.user.NotEmailUserException;
@@ -16,7 +10,6 @@ import com.floney.floney.user.dto.response.ReceiveMarketingResponse;
 import com.floney.floney.user.entity.User;
 import com.floney.floney.user.repository.SignoutReasonRepository;
 import com.floney.floney.user.repository.UserRepository;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +17,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -43,7 +42,7 @@ class UserServiceTest {
     private SignoutReasonRepository signoutReasonRepository;
     @Mock
     private MailProvider mailProvider;
-
+   
     @Test
     @DisplayName("마케팅 수신 동의 여부를 변경하는데 성공한다")
     void updateReceiveMarketing_success() {
@@ -53,7 +52,7 @@ class UserServiceTest {
 
         // when & then
         assertThatNoException()
-                .isThrownBy(() -> userService.updateReceiveMarketing(false, user.getEmail()));
+            .isThrownBy(() -> userService.updateReceiveMarketing(false, user.getEmail()));
         assertThat(user.isReceiveMarketing()).isFalse();
     }
 
@@ -66,7 +65,7 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.updateReceiveMarketing(false, email))
-                .isInstanceOf(UserNotFoundException.class);
+            .isInstanceOf(UserNotFoundException.class);
     }
 
     @Test
@@ -86,7 +85,7 @@ class UserServiceTest {
     void updateRegeneratedPassword_fail_throws_userNotFoundException() {
         // when & then
         assertThatThrownBy(() -> userService.updatePasswordByGeneration("notUser"))
-                .isInstanceOf(UserNotFoundException.class);
+            .isInstanceOf(UserNotFoundException.class);
     }
 
 
@@ -101,7 +100,7 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.updatePasswordByGeneration(email))
-                .isInstanceOf(NotEmailUserException.class);
+            .isInstanceOf(NotEmailUserException.class);
     }
 
     @Test
@@ -126,6 +125,6 @@ class UserServiceTest {
 
         // when
         assertThatThrownBy(() -> userService.getReceiveMarketing("fail@email.com"))
-                .isInstanceOf(UserNotFoundException.class);
+            .isInstanceOf(UserNotFoundException.class);
     }
 }

--- a/src/test/java/com/floney/floney/user/service/UserServiceTest.java
+++ b/src/test/java/com/floney/floney/user/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
@@ -42,7 +43,9 @@ class UserServiceTest {
     private SignoutReasonRepository signoutReasonRepository;
     @Mock
     private MailProvider mailProvider;
-   
+    @Mock
+    private PasswordHistoryManager passwordHistoryManager;
+
     @Test
     @DisplayName("마케팅 수신 동의 여부를 변경하는데 성공한다")
     void updateReceiveMarketing_success() {
@@ -73,6 +76,7 @@ class UserServiceTest {
     void updateRegeneratedPassword_success() {
         // given
         final User user = UserFixture.emailUser();
+        ReflectionTestUtils.setField(user, "id", 1L);
 
         given(userRepository.findByEmail(user.getEmail())).willReturn(Optional.of(user));
 


### PR DESCRIPTION
## 📌 개요

비밀번호 5번 이상 변경 이후 이전에 사용한 예전 비밀번호 사용 가능

## ✅ 개발 내용

- 레디스를 사용해 회원마다 비밀번호 내역 저장
- `PasswordHistoryManager` 클래스에서 비밀번호 내역 관리 담당
- 관련 테스트 추가
- 인수 & 통합 테스트 시 테스트 마다 레디스 초기화
