### PR TITLE
#368 refactor: logger 파일 보완

### DIFF
--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,17 +1,18 @@
 <included>
     <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/home/ubuntu/Floney-Server/log/error/error-${BY_DATE}.log</file>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
         </filter>
         <encoder>
             <pattern>${LOG_FILE_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
+            <fileNamePattern>/home/ubuntu/Floney-Server/backup/error/error-%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
             <maxHistory>30</maxHistory>
-            <totalSizeCap>3GB</totalSizeCap>
+            <totalSizeCap>2GB</totalSizeCap>
         </rollingPolicy>
     </appender>
 </included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -8,10 +8,10 @@
             <pattern>${LOG_FILE_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./backup/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
+            <fileNamePattern>/home/ubuntu/Floney-Server/backup/info/info-%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
             <maxHistory>30</maxHistory>
-            <totalSizeCap>3GB</totalSizeCap>
+            <totalSizeCap>2GB</totalSizeCap>
         </rollingPolicy>
     </appender>
 </included>

--- a/src/main/resources/file-warn-appender.xml
+++ b/src/main/resources/file-warn-appender.xml
@@ -1,17 +1,18 @@
 <included>
     <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/home/ubuntu/Floney-Server/log/warn/warn-${BY_DATE}.log</file>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
         </filter>
         <encoder>
             <pattern>${LOG_FILE_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
+            <fileNamePattern>/home/ubuntu/Floney-Server/backup/warn/warn-%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
             <maxHistory>30</maxHistory>
-            <totalSizeCap>3GB</totalSizeCap>
+            <totalSizeCap>2GB</totalSizeCap>
         </rollingPolicy>
     </appender>
 </included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -29,8 +29,6 @@
 
         <logger name="LogByAop" additivity="false">
             <appender-ref ref="FILE-INFO"/>
-            <appender-ref ref="FILE-WARN"/>
-            <appender-ref ref="FILE-ERROR"/>
         </logger>
 
         <logger name="ErrorControllerAdvice" additivity="false">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,20 +6,20 @@
               value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] %green([%thread]) %highlight(%-5level) %logger{40} - %msg%n"/>
     <property name="LOG_FILE_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %-5level %logger{40} - %msg%n"/>
 
+    <!-- local profile 사용 시 -->
     <springProfile name="local">
         <include resource="console-appender.xml"/>
-
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
 
-    <springProfile name="develop,local,production">
+    <!-- develop,production profile 사용 시 -->
+    <springProfile name="develop,production">
         <include resource="file-info-appender.xml"/>
         <include resource="file-warn-appender.xml"/>
         <include resource="file-error-appender.xml"/>
         <include resource="slack-error-appender.xml"/>
-        <include resource="console-appender.xml"/>
 
         <root level="INFO">
             <appender-ref ref="FILE-INFO"/>
@@ -28,25 +28,15 @@
         </root>
 
         <logger name="LogByAop" additivity="false">
-            <level value = "DEBUG" />
-            <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE-INFO"/>
             <appender-ref ref="FILE-WARN"/>
             <appender-ref ref="FILE-ERROR"/>
         </logger>
 
         <logger name="ErrorControllerAdvice" additivity="false">
-            <level value = "DEBUG" />
-            <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE-ERROR"/>
-            <springProfile name = "develop,production">
-                <appender-ref ref="ASYNC_SLACK"/>
-            </springProfile>
+            <appender-ref ref="ASYNC_SLACK"/>
         </logger>
 
-        <logger name="org.hibernate.SQL" additivity="false">
-            <level value = "DEBUG"/>
-            <appender-ref ref="CONSOLE"/>
-        </logger>
     </springProfile>
 </configuration>


### PR DESCRIPTION
## 📌 개요

Logger 폴더 크기 조절, 및 xml 코드 정리

## ✅ 개발 내용

- Logger 폴더 생성 시 일정 크기 넘어가면 압축
- 30일까지 보관 후, 삭제
- 일치하는 level만 해당 파일에 log작성하도록 ex. error 폴더에는 error만

단, 현재는 전반적으로 log메세지가 명확하지 않은 상태이므로, 에러가 터지면 앞 뒤 맥락을 파악하기 어려움.
따라서 info 폴더 출력시에만 전체 흐름을 보기 위해 모든 레벨을 출력하도록 설정(info,warn,error)
차후에 log메세지를 명확히 수정 후, info 에 level 제한을 걸 예정(#318 머지 후)
