### PR TITLE
#380 fix: 비밀번호 변경 시 현재 비밀번호도 검증

### DIFF
--- a/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
@@ -37,103 +37,103 @@ public class ErrorControllerAdvice {
         logger.warn("이미 존재하는 유저: [{}]", exception.getEmail());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(body);
+            .body(body);
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     protected ResponseEntity<ErrorResponse> notFoundUser(UserNotFoundException exception) {
         logger.warn("저장되지 않은 유저 정보: [{}]", exception.getUsername());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(MailAddressException.class)
     protected ResponseEntity<ErrorResponse> notValidMailAddress(MailAddressException exception) {
         logger.warn("유효하지 않은 메일 주소: [{}]", exception.getEmail());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(MailException.class)
     protected ResponseEntity<ErrorResponse> failToSendMail(MailException exception) {
         logger.error("메일 전송 오류 \n [ERROR_MSG] : {} \n [ERROR STACK] : {}", exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(ErrorType.FAIL_TO_SEND_MAIL));
+            .body(ErrorResponse.of(ErrorType.FAIL_TO_SEND_MAIL));
     }
 
     @ExceptionHandler(ExpiredJwtException.class)
     protected ResponseEntity<ErrorResponse> expiredJwtToken(ExpiredJwtException exception) {
         logger.warn("만료된 토큰");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(ErrorType.EXPIRED_JWT_TOKEN));
+            .body(ErrorResponse.of(ErrorType.EXPIRED_JWT_TOKEN));
     }
 
     @ExceptionHandler(JwtException.class)
     protected ResponseEntity<ErrorResponse> invalidJwtToken(JwtException exception) {
         logger.warn("유효하지 않은 JWT 토큰: {}", exception.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(ErrorType.INVALID_JWT_TOKEN));
+            .body(ErrorResponse.of(ErrorType.INVALID_JWT_TOKEN));
     }
 
     @ExceptionHandler(BadCredentialsException.class)
     protected ResponseEntity<ErrorResponse> invalidLogin(BadCredentialsException exception) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(ErrorType.INVALID_LOGIN));
+            .body(ErrorResponse.of(ErrorType.INVALID_LOGIN));
     }
 
     @ExceptionHandler(EmailNotFoundException.class)
     protected ResponseEntity<ErrorResponse> emailNotFound(EmailNotFoundException exception) {
         logger.warn("이메일({}) 찾기 실패", exception.getEmail());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(CodeNotSameException.class)
     protected ResponseEntity<ErrorResponse> invalidCode(CodeNotSameException exception) {
         logger.debug("일치하지 않는 이메일 인증 코드: [{}], [{}]", exception.getCode(), exception.getAnotherCode());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(CodeNotFoundException.class)
     protected ResponseEntity<ErrorResponse> notExistCode(CodeNotFoundException exception) {
         logger.debug("이메일[{}] 인증 시간 만료", exception.getEmail());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(OAuthResponseException.class)
     protected ResponseEntity<ErrorResponse> badOAuthResponse(OAuthResponseException exception) {
         logger.error("외부 로그인 서버에서 빈 응답을 받음 \n [ERROR_MSG] : {} \n [ERROR STACK] : {}", exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(OAuthTokenNotValidException.class)
     protected ResponseEntity<ErrorResponse> invalidOAuthToken(OAuthTokenNotValidException exception) {
         logger.warn("외부 로그인 서버에서 잘못된 토큰으로 인한 인증 실패");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(SignoutOtherReasonEmptyException.class)
     protected ResponseEntity<ErrorResponse> signoutOtherReasonEmpty(SignoutOtherReasonEmptyException exception) {
         logger.warn("회원 탈퇴 요청에서 value가 비어있음");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotEmailUserException.class)
     protected ResponseEntity<ErrorResponse> notEmailUser(NotEmailUserException exception) {
         logger.warn("이메일 유저가 아니라 간편 유저({})임", exception.getProvider());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(PasswordSameException.class)
     protected ResponseEntity<ErrorResponse> samePassword(PasswordSameException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     // BOOK
@@ -141,93 +141,93 @@ public class ErrorControllerAdvice {
     protected ResponseEntity<ErrorResponse> notFoundBook(NotFoundBookException exception) {
         logger.warn("가계부 키 [{}] 가계부 {}", exception.getRequestKey(), ErrorType.NOT_FOUND_BOOK.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(MaxMemberException.class)
     protected ResponseEntity<ErrorResponse> maxMember(MaxMemberException exception) {
         logger.warn("가계부 키 [{}] 가계부 {} => 현 인원[{}]", exception.getBookKey(),
-                ErrorType.MAX_MEMBER.getMessage(),
-                exception.getMemberCount());
+            ErrorType.MAX_MEMBER.getMessage(),
+            exception.getMemberCount());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotFoundCategoryException.class)
     protected ResponseEntity<ErrorResponse> notFoundCategory(NotFoundCategoryException exception) {
         logger.warn("[{}] {}", exception.getCategoryName(), ErrorType.NOT_FOUND_CATEGORY.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(CannotDeleteBookException.class)
     protected ResponseEntity<ErrorResponse> cannotDeleteBook(CannotDeleteBookException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotFoundBookUserException.class)
     protected ResponseEntity<ErrorResponse> notFoundUser(NotFoundBookUserException exception) {
         logger.warn("가계부 키 [{}] 에서 [{}]와 일치하는 {}",
-                exception.getBookKey(),
-                exception.getRequestUser(),
-                ErrorType.NOT_FOUND_BOOK_USER.getMessage());
+            exception.getBookKey(),
+            exception.getRequestUser(),
+            ErrorType.NOT_FOUND_BOOK_USER.getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotFoundBookLineException.class)
     protected ResponseEntity<ErrorResponse> notFoundLine(NotFoundBookLineException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(ExcelMakingException.class)
     protected ResponseEntity<ErrorResponse> excelError(ExcelMakingException exception) {
         logger.error("엑셀 오류 발생 [ERROR_MSG] : {} \n [ERROR_STACK] : {} \n ", exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(LimitRequestException.class)
     protected ResponseEntity<ErrorResponse> limitOfService(LimitRequestException exception) {
         logger.warn(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NoAuthorityException.class)
     protected ResponseEntity<ErrorResponse> notOwner(NoAuthorityException exception) {
         logger.warn("{} : 가계부 방장 [{}] , 요청자 [{}]",
-                exception.getOwner(),
-                ErrorType.NO_AUTHORITY.getMessage(),
-                exception.getRequestUser());
+            exception.getOwner(),
+            ErrorType.NO_AUTHORITY.getMessage(),
+            exception.getRequestUser());
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(AlreadyJoinException.class)
     protected ResponseEntity<ErrorResponse> joinException(AlreadyJoinException exception) {
         logger.warn("{}는 {} \n [ERROR_MSG] : {} \n  [ERROR_STACK] : {}", exception.getUserEmail(), ErrorType.ALREADY_JOIN.getMessage(), exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(NotFoundAlarmException.class)
     protected ResponseEntity<ErrorResponse> alarmException(NotFoundAlarmException exception) {
         logger.error("{} id = {} \n [ERROR_MSG] : {} \n [ERROR_STACK] : {}", ErrorType.NOT_FOUND_ALARM.getMessage(), exception.getRequestKey(), exception.getMessage(), exception.getStackTrace());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(AlreadyExistException.class)
     protected ResponseEntity<ErrorResponse> alreadyExistException(AlreadyExistException exception) {
         logger.warn("{} data = {}", ErrorType.ALREADY_EXIST.getMessage(), exception.getTarget());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     // SETTLEMENT
@@ -235,21 +235,21 @@ public class ErrorControllerAdvice {
     protected ResponseEntity<ErrorResponse> settlementNotFoundException(SettlementNotFoundException exception) {
         logger.warn("settlement id [{}]의 정산 내역이 존재하지 않음", exception.getSettlementId());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     @ExceptionHandler(OutcomeUserNotFoundException.class)
     protected ResponseEntity<ErrorResponse> outcomeUserNotFoundException(OutcomeUserNotFoundException exception) {
         logger.warn("Request Body에서 지출 내역의 유저가 유저 목록에 존재하지 않음");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     // ALARM
     @ExceptionHandler(GoogleAccessTokenGenerateException.class)
     protected ResponseEntity<ErrorResponse> failToGenerateGoogleAccessTokenException(GoogleAccessTokenGenerateException exception) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(exception.getErrorType()));
+            .body(ErrorResponse.of(exception.getErrorType()));
     }
 
     // OTHER
@@ -259,7 +259,7 @@ public class ErrorControllerAdvice {
         logger.warn("요청 body의 @Valid 에러 - [{}] : {} ", exception.getTarget(), message);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(ErrorType.REQUEST_BODY_ERROR, message));
+            .body(ErrorResponse.of(ErrorType.REQUEST_BODY_ERROR, message));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
@@ -267,14 +267,14 @@ public class ErrorControllerAdvice {
         logger.warn("요청 파라미터 없음 : {} ", exception.getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(ErrorType.REQUEST_PARAMETER_ERROR, exception.getMessage()));
+            .body(ErrorResponse.of(ErrorType.REQUEST_PARAMETER_ERROR, exception.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> otherException(Exception exception) {
         loggingError(exception);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(ErrorType.SERVER_ERROR));
+            .body(ErrorResponse.of(ErrorType.SERVER_ERROR));
     }
 
     private void loggingError(final Exception exception) {

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
@@ -136,6 +136,12 @@ public class ErrorControllerAdvice {
             .body(ErrorResponse.of(exception.getErrorType()));
     }
 
+    @ExceptionHandler(PasswordNotSameException.class)
+    protected ResponseEntity<ErrorResponse> notSamePassword(PasswordNotSameException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.of(exception.getErrorType()));
+    }
+
     // BOOK
     @ExceptionHandler(NotFoundBookException.class)
     protected ResponseEntity<ErrorResponse> notFoundBook(NotFoundBookException exception) {

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorType.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorType.java
@@ -30,6 +30,7 @@ public enum ErrorType {
     EMPTY_SIGNOUT_OTHER_REASON("U019", "기타 탈퇴 사유가 없습니다"),
     SUBSCRIBE("U020", "구독자 입니다"),
     NOT_EMAIL_USER("U021", "이메일 유저가 아닙니다"),
+    NOT_SAME_PASSWORD("U022", "비밀번호가 같지 않습니다"),
 
     NOT_FOUND_BOOK("B001", "가계부가 존재하지 않습니다"),
     MAX_MEMBER("B002", "최대 인원이 초과되었습니다"),

--- a/src/main/java/com/floney/floney/common/exception/user/PasswordNotSameException.java
+++ b/src/main/java/com/floney/floney/common/exception/user/PasswordNotSameException.java
@@ -1,0 +1,14 @@
+package com.floney.floney.common.exception.user;
+
+import com.floney.floney.common.exception.common.ErrorType;
+import lombok.Getter;
+
+@Getter
+public class PasswordNotSameException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    public PasswordNotSameException() {
+        this.errorType = ErrorType.NOT_SAME_PASSWORD;
+    }
+}

--- a/src/main/java/com/floney/floney/user/controller/UserController.java
+++ b/src/main/java/com/floney/floney/user/controller/UserController.java
@@ -136,9 +136,9 @@ public class UserController {
      */
     @PutMapping("/password")
     @ResponseStatus(HttpStatus.OK)
-    public void updatePassword(@RequestBody final UpdatePasswordRequest request,
+    public void updatePassword(@RequestBody @Valid final UpdatePasswordRequest request,
                                @AuthenticationPrincipal final CustomUserDetails userDetails) {
-        userService.updatePassword(request.getNewPassword(), userDetails.getUsername());
+        userService.updatePassword(request, userDetails.getUsername());
     }
 
     /**

--- a/src/main/java/com/floney/floney/user/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/floney/floney/user/dto/request/UpdatePasswordRequest.java
@@ -16,4 +16,8 @@ public class UpdatePasswordRequest {
     @NotNull(message = "새 비밀번호를 입력해주세요")
     @NotBlank(message = "새 비밀번호를 입력해주세요")
     private String newPassword;
+
+    @NotNull(message = "기존 비밀번호를 입력해주세요")
+    @NotBlank(message = "기존 비밀번호를 입력해주세요")
+    private String oldPassword;
 }

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.floney.floney.book.dto.process.MyBookInfo;
 import com.floney.floney.book.dto.request.SaveRecentBookKeyRequest;
 import com.floney.floney.book.repository.BookRepository;
 import com.floney.floney.book.repository.BookUserRepository;
+import com.floney.floney.common.exception.user.PasswordNotSameException;
 import com.floney.floney.common.exception.user.PasswordSameException;
 import com.floney.floney.common.exception.user.UserFoundException;
 import com.floney.floney.common.exception.user.UserNotFoundException;
@@ -15,6 +16,7 @@ import com.floney.floney.user.dto.constant.SignoutType;
 import com.floney.floney.user.dto.request.LoginRequest;
 import com.floney.floney.user.dto.request.SignoutRequest;
 import com.floney.floney.user.dto.request.SignupRequest;
+import com.floney.floney.user.dto.request.UpdatePasswordRequest;
 import com.floney.floney.user.dto.response.MyPageResponse;
 import com.floney.floney.user.dto.response.ReceiveMarketingResponse;
 import com.floney.floney.user.dto.response.SignoutResponse;
@@ -92,9 +94,10 @@ public class UserService {
         userRepository.save(user);
     }
 
-    public void updatePassword(final String password, final String email) {
+    public void updatePassword(final UpdatePasswordRequest request, final String email) {
         final User user = findUserByEmail(email);
-        updatePassword(password, user);
+        validatePasswordSame(request.getOldPassword(), user.getPassword());
+        updatePassword(request.getNewPassword(), user);
     }
 
     public void updatePasswordByGeneration(final String email) {
@@ -131,6 +134,12 @@ public class UserService {
     @Transactional(readOnly = true)
     public ReceiveMarketingResponse getReceiveMarketing(final String email) {
         return new ReceiveMarketingResponse(findUserByEmail(email).isReceiveMarketing());
+    }
+
+    private void validatePasswordSame(final String rawPassword, final String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new PasswordNotSameException();
+        }
     }
 
     private void leaveBooks(final User user,


### PR DESCRIPTION
## 📌 개요

비밀번호 변경 API 에서 현재 비밀번호를 검증하지 않던 오류를 수정한다.

## ✅ 개발 내용

- 현재 비밀번호를 검증 추가
