### PR TITLE
#384 fix : User inactive() 이전, User 탈퇴 이벤트 시행

### DIFF
--- a/src/main/java/com/floney/floney/user/entity/User.java
+++ b/src/main/java/com/floney/floney/user/entity/User.java
@@ -143,9 +143,8 @@ public class User extends BaseEntity {
 
     public void signout() {
         deleteInformation();
-        inactive();
-
         Events.raise(new UserSignedOutEvent(getId()));
+        inactive();
     }
 
     private void deleteInformation() {


### PR DESCRIPTION
## 📌 개요

회원 탈퇴시, 가계부 내역이 존재하지 않음 에러 발생으로 인한 이슈 해결

## ✅ 개발 내용

- User inactive() 이전, User 탈퇴 이벤트 시행
