### PR TITLE
#403 feat: 비밀번호 변경 조건 삭제

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*.java @sienna011022 @dahyen0o
+*.java @sienna011022 @dahyen0o @sejeongsong

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -32,10 +32,11 @@ jobs:
         run: ./gradlew clean build
 
       - name: 테스트 결과를 PR에 코멘트로 등록
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: '**/build/test-results/test/TEST-*.xml'
+          files: |
+            test-results/**/*.xml
 
       - name: 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -35,8 +35,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: |
-            test-results/**/*.xml
+          files: '**/build/test-results/test/TEST-*.xml'
 
       - name: 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록
         uses: mikepenz/action-junit-report@v3

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -55,14 +55,12 @@ public class UserService {
     private final SignoutReasonRepository signoutReasonRepository;
     private final SignoutOtherReasonRepository signoutOtherReasonRepository;
     private final MailProvider mailProvider;
-    private final PasswordHistoryManager passwordHistoryManager;
 
     public LoginRequest signup(SignupRequest request) {
         validateUserExistByEmail(request.getEmail());
         final User user = request.to();
         user.encodePassword(passwordEncoder);
         userRepository.save(user);
-        passwordHistoryManager.addPassword(user.getPassword(), user.getId());
         return request.toLoginRequest();
     }
 
@@ -76,7 +74,6 @@ public class UserService {
 
         user.signout();
         addSignoutReason(request);
-        passwordHistoryManager.deleteHistory(user.getId());
 
         return SignoutResponse.of(deletedBookKeys, notDeletedBookKeys);
     }

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -179,9 +179,8 @@ public class UserService {
         signoutOtherReasonRepository.save(signoutOtherReason);
     }
 
-    private void updatePassword(String newPassword, User user) {
+    private void updatePassword(final String newPassword, final User user) {
         validatePasswordNotSame(newPassword, user);
-        passwordHistoryManager.addPassword(newPassword, user.getId());
         user.updatePassword(newPassword);
         user.encodePassword(passwordEncoder);
     }

--- a/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
+++ b/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
@@ -13,8 +13,8 @@ import javax.annotation.Resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@Disabled
-@DisplayName("PasswordValidator 테스트")
+@Disabled("사용하지 않는 객체")
+@DisplayName("PasswordHistoryManager 테스트")
 @SpringBootTest
 class PasswordHistoryManagerTest {
 

--- a/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
+++ b/src/test/java/com/floney/floney/user/service/PasswordHistoryManagerTest.java
@@ -13,6 +13,7 @@ import javax.annotation.Resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@Disabled
 @DisplayName("PasswordValidator 테스트")
 @SpringBootTest
 class PasswordHistoryManagerTest {

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -42,7 +42,3 @@ jwt:
 server:
   error:
     include-message: always
-
-logging:
-  level:
-    sql: debug


### PR DESCRIPTION
## 📌 개요

최근 변경한 5개의 비밀번호와 새 비밀번호가 겹치면 안된다는 조건을 삭제했다.

## ✅ 개발 내용

- PasswordHistoryManager 테스트 무효화
- PasswordHistoryManager를 사용하는 코드 삭제
