### PR TITLE
#409 fix: 반복 내역 성능 개선

### DIFF
--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -77,17 +77,18 @@ public class AssetServiceImpl implements AssetService {
         if (TRANSFER.equals(categoryType)) {
             return;
         }
+
         List<Asset> assets = new ArrayList<>();
         final LocalDate startMonth = DateUtil.getFirstDayOfMonth(bookLine.getLineDate());
 
         for (int month = 0; month < SAVE_ASSET_DURATION; month++) {
             final LocalDate currentMonth = startMonth.plusMonths(month);
             assets.add(Asset.of(bookLine, categoryType, currentMonth));
-
         }
 
         assetJdbcRepository.saveAll(assets);
     }
+
 
     @Override
     @Transactional

--- a/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/AssetServiceImpl.java
@@ -1,10 +1,11 @@
 package com.floney.floney.analyze.service;
 
-import com.floney.floney.book.domain.category.entity.Category;
+import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.book.domain.entity.Asset;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookLine;
 import com.floney.floney.book.dto.process.AssetInfo;
+import com.floney.floney.book.repository.AssetJdbcRepository;
 import com.floney.floney.book.repository.BookLineRepository;
 import com.floney.floney.book.repository.analyze.AssetRepository;
 import com.floney.floney.book.util.DateUtil;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +34,7 @@ public class AssetServiceImpl implements AssetService {
     private static final int ONE_MONTH = 1;
 
     private final AssetRepository assetRepository;
+    private final AssetJdbcRepository assetJdbcRepository;
     private final BookLineRepository bookLineRepository;
 
     @Override
@@ -67,20 +70,23 @@ public class AssetServiceImpl implements AssetService {
     @Transactional
     public void addAssetOf(final BookLine bookLine) {
 
-        Category lineCategory = bookLine.getCategories().getLineCategory();
+        CategoryType categoryType = bookLine.getCategories().getLineCategory().getName();
 
         // 이체 내역일 경우 자산 포함 X
         // TODO: 파라미터에 BookLineRequest을 BookLine으로 대체한 후 검증 로직 추가
-        if (TRANSFER.equals(lineCategory.getName())) {
+        if (TRANSFER.equals(categoryType)) {
             return;
         }
-
+        List<Asset> assets = new ArrayList<>();
         final LocalDate startMonth = DateUtil.getFirstDayOfMonth(bookLine.getLineDate());
 
         for (int month = 0; month < SAVE_ASSET_DURATION; month++) {
             final LocalDate currentMonth = startMonth.plusMonths(month);
-            assetRepository.upsertMoneyByDateAndBook(currentMonth, bookLine.getBook(), getMoney(bookLine));
+            assets.add(Asset.of(bookLine, categoryType, currentMonth));
+
         }
+
+        assetJdbcRepository.saveAll(assets);
     }
 
     @Override

--- a/src/main/java/com/floney/floney/analyze/service/CarryOverServiceImpl.java
+++ b/src/main/java/com/floney/floney/analyze/service/CarryOverServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.floney.floney.book.domain.category.CategoryType.TRANSFER;
 import static com.floney.floney.common.constant.Status.ACTIVE;
 
 @Service
@@ -63,7 +64,7 @@ public class CarryOverServiceImpl implements CarryOverService {
         CategoryType categoryType = bookLine.getCategories().getLineCategory().getName();
 
         // 카테고리가 이체인 경우 생성 X
-        if (categoryType.isTransfer()) {
+        if (TRANSFER.equals(categoryType)) {
             return;
         }
 
@@ -74,7 +75,8 @@ public class CarryOverServiceImpl implements CarryOverService {
 
         for (int i = 0; i < SAVE_CARRY_OVER_DURATION; i++) {
             targetDate = getNextMonth(targetDate);
-            carryOverList.add(CarryOver.getCarryOverToAdd(bookLine, targetDate));
+            CarryOver carryOver = CarryOver.of(bookLine, targetDate);
+            carryOverList.add(carryOver);
         }
 
         carryOverJdbcRepository.saveAll(carryOverList);
@@ -87,7 +89,7 @@ public class CarryOverServiceImpl implements CarryOverService {
         final BookLine bookLine = bookLineRepository.findById(bookLineId).orElseThrow(NotFoundBookLineException::new);
         CategoryType categoryType = bookLine.getCategories().getLineCategory().getName();
 
-        if (!bookLine.getBook().getCarryOverStatus() || categoryType.isTransfer()) {
+        if (!bookLine.getBook().getCarryOverStatus() || TRANSFER.equals(categoryType)) {
             return;
         }
 
@@ -96,7 +98,8 @@ public class CarryOverServiceImpl implements CarryOverService {
 
         for (int i = 0; i < SAVE_CARRY_OVER_DURATION; i++) {
             targetDate = getNextMonth(targetDate);
-            carryOverList.add(CarryOver.getCarryOverToDelete(bookLine, targetDate));
+            CarryOver carryOver = CarryOver.of(bookLine, targetDate);
+            carryOverList.add(carryOver.delete(categoryType));
         }
 
         carryOverJdbcRepository.saveAll(carryOverList);

--- a/src/main/java/com/floney/floney/book/domain/category/CategoryType.java
+++ b/src/main/java/com/floney/floney/book/domain/category/CategoryType.java
@@ -40,8 +40,4 @@ public enum CategoryType {
     public static boolean isLine(final CategoryType categoryType) {
         return INCOME.equals(categoryType) || OUTCOME.equals(categoryType) || TRANSFER.equals(categoryType);
     }
-
-    public boolean isTransfer() {
-        return this == CategoryType.TRANSFER;
-    }
 }

--- a/src/main/java/com/floney/floney/book/domain/category/CategoryType.java
+++ b/src/main/java/com/floney/floney/book/domain/category/CategoryType.java
@@ -40,4 +40,8 @@ public enum CategoryType {
     public static boolean isLine(final CategoryType categoryType) {
         return INCOME.equals(categoryType) || OUTCOME.equals(categoryType) || TRANSFER.equals(categoryType);
     }
+
+    public boolean isTransfer() {
+        return this == CategoryType.TRANSFER;
+    }
 }

--- a/src/main/java/com/floney/floney/book/domain/entity/Asset.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/Asset.java
@@ -1,5 +1,6 @@
 package com.floney.floney.book.domain.entity;
 
+import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.book.dto.request.BookLineRequest;
 import com.floney.floney.common.entity.BaseEntity;
 import lombok.*;
@@ -46,6 +47,24 @@ public class Asset extends BaseEntity {
             .date(date)
             .build();
     }
+
+    public static Asset of(final BookLine bookLine,
+                           final CategoryType categoryType,
+                           final LocalDate date) {
+        if (OUTCOME.equals(categoryType)) {
+            return Asset.builder()
+                .money(-1 * bookLine.getMoney())
+                .book(bookLine.getBook())
+                .date(date)
+                .build();
+        }
+        return Asset.builder()
+            .money(bookLine.getMoney())
+            .book(bookLine.getBook())
+            .date(date)
+            .build();
+    }
+
 
     public void add(final double money, final String flow) {
         if (INCOME.getMeaning().equals(flow)) {

--- a/src/main/java/com/floney/floney/book/domain/entity/Asset.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/Asset.java
@@ -1,7 +1,6 @@
 package com.floney.floney.book.domain.entity;
 
 import com.floney.floney.book.domain.category.CategoryType;
-import com.floney.floney.book.dto.request.BookLineRequest;
 import com.floney.floney.common.entity.BaseEntity;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -31,23 +30,6 @@ public class Asset extends BaseEntity {
 
     private LocalDate date;
 
-    public static Asset of(final BookLineRequest request,
-                           final Book book,
-                           final LocalDate date) {
-        if (OUTCOME.getMeaning().equals(request.getFlow())) {
-            return Asset.builder()
-                .money(-1 * request.getMoney())
-                .book(book)
-                .date(date)
-                .build();
-        }
-        return Asset.builder()
-            .money(request.getMoney())
-            .book(book)
-            .date(date)
-            .build();
-    }
-
     public static Asset of(final BookLine bookLine,
                            final CategoryType categoryType,
                            final LocalDate date) {
@@ -64,7 +46,6 @@ public class Asset extends BaseEntity {
             .date(date)
             .build();
     }
-
 
     public void add(final double money, final String flow) {
         if (INCOME.getMeaning().equals(flow)) {

--- a/src/main/java/com/floney/floney/book/domain/entity/CarryOver.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/CarryOver.java
@@ -1,6 +1,8 @@
 package com.floney.floney.book.domain.entity;
 
+import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.book.domain.category.entity.Category;
+import com.floney.floney.book.dto.request.BookLineRequest;
 import com.floney.floney.common.entity.BaseEntity;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
@@ -15,8 +17,7 @@ import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import java.time.LocalDate;
 
-import static com.floney.floney.book.domain.category.CategoryType.INCOME;
-import static com.floney.floney.book.domain.category.CategoryType.OUTCOME;
+import static com.floney.floney.book.domain.category.CategoryType.*;
 
 @Entity
 @Getter
@@ -40,26 +41,24 @@ public class CarryOver extends BaseEntity {
         this.date = date;
     }
 
-    public static CarryOver getCarryOverToAdd(final BookLine bookLine, final LocalDate date) {
-        Category category = bookLine.getCategories().getLineCategory();
-        if (OUTCOME.equals(category.getName())) {
+    public static CarryOver of(final BookLineRequest request, final Book book, final LocalDate date) {
+        if (OUTCOME.getMeaning().equals(request.getFlow())) {
             return CarryOver.builder()
-                .money(-1 * bookLine.getMoney())
-                .book(bookLine.getBook())
+                .money(-1 * request.getMoney())
+                .book(book)
                 .date(date)
                 .build();
         }
         return CarryOver.builder()
-            .money(bookLine.getMoney())
-            .book(bookLine.getBook())
+            .money(request.getMoney())
+            .book(book)
             .date(date)
             .build();
     }
 
-    // 가계부 내역 삭제 시, 이월 금액에서 현재 내역을 취소 용
-    public static CarryOver getCarryOverToDelete(final BookLine bookLine, final LocalDate date) {
+    public static CarryOver of(final BookLine bookLine, final LocalDate date) {
         Category category = bookLine.getCategories().getLineCategory();
-        if (INCOME.equals(category.getName())) {
+        if (OUTCOME.equals(category.getName())) {
             return CarryOver.builder()
                 .money(-1 * bookLine.getMoney())
                 .book(bookLine.getBook())
@@ -79,4 +78,27 @@ public class CarryOver extends BaseEntity {
             .build();
     }
 
+    public void update(final double updateMoney, final CategoryType categoryType) {
+        if (INCOME.equals(categoryType)) {
+            money += updateMoney;
+        } else {
+            money -= updateMoney;
+        }
+    }
+
+    public CarryOver delete(CategoryType categoryType) {
+        if (TRANSFER.equals(categoryType)) {
+            return CarryOver.builder()
+                .money(this.money)
+                .book(book)
+                .date(date)
+                .build();
+        }
+
+        return CarryOver.builder()
+            .money(-1 * this.money)
+            .book(book)
+            .date(date)
+            .build();
+    }
 }

--- a/src/main/java/com/floney/floney/book/domain/entity/CarryOver.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/CarryOver.java
@@ -1,8 +1,6 @@
 package com.floney.floney.book.domain.entity;
 
-import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.book.domain.category.entity.Category;
-import com.floney.floney.book.dto.request.BookLineRequest;
 import com.floney.floney.common.entity.BaseEntity;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
@@ -42,24 +40,26 @@ public class CarryOver extends BaseEntity {
         this.date = date;
     }
 
-    public static CarryOver of(final BookLineRequest request, final Book book, final LocalDate date) {
-        if (OUTCOME.getMeaning().equals(request.getFlow())) {
+    public static CarryOver getCarryOverToAdd(final BookLine bookLine, final LocalDate date) {
+        Category category = bookLine.getCategories().getLineCategory();
+        if (OUTCOME.equals(category.getName())) {
             return CarryOver.builder()
-                .money(-1 * request.getMoney())
-                .book(book)
+                .money(-1 * bookLine.getMoney())
+                .book(bookLine.getBook())
                 .date(date)
                 .build();
         }
         return CarryOver.builder()
-            .money(request.getMoney())
-            .book(book)
+            .money(bookLine.getMoney())
+            .book(bookLine.getBook())
             .date(date)
             .build();
     }
 
-    public static CarryOver of(final BookLine bookLine, final LocalDate date) {
+    // 가계부 내역 삭제 시, 이월 금액에서 현재 내역을 취소 용
+    public static CarryOver getCarryOverToDelete(final BookLine bookLine, final LocalDate date) {
         Category category = bookLine.getCategories().getLineCategory();
-        if (OUTCOME.equals(category.getName())) {
+        if (INCOME.equals(category.getName())) {
             return CarryOver.builder()
                 .money(-1 * bookLine.getMoney())
                 .book(bookLine.getBook())
@@ -79,21 +79,4 @@ public class CarryOver extends BaseEntity {
             .build();
     }
 
-    public void update(final double updateMoney, final CategoryType categoryType) {
-        if (INCOME.equals(categoryType)) {
-            money += updateMoney;
-        } else {
-            money -= updateMoney;
-        }
-    }
-
-    // 내역을 삭제하는 경우, 이월된 값을 되돌리기
-    public void delete(final double updateMoney, final BookLineCategory bookLineCategory) {
-        if (!bookLineCategory.isIncomeOrOutcome()) return;
-        if (bookLineCategory.isIncome()) {
-            money -= updateMoney;
-        } else {
-            money += updateMoney;
-        }
-    }
 }

--- a/src/main/java/com/floney/floney/book/domain/entity/CarryOver.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/CarryOver.java
@@ -2,7 +2,6 @@ package com.floney.floney.book.domain.entity;
 
 import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.book.domain.category.entity.Category;
-import com.floney.floney.book.dto.request.BookLineRequest;
 import com.floney.floney.common.entity.BaseEntity;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
@@ -17,7 +16,8 @@ import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import java.time.LocalDate;
 
-import static com.floney.floney.book.domain.category.CategoryType.*;
+import static com.floney.floney.book.domain.category.CategoryType.OUTCOME;
+import static com.floney.floney.book.domain.category.CategoryType.TRANSFER;
 
 @Entity
 @Getter
@@ -41,21 +41,6 @@ public class CarryOver extends BaseEntity {
         this.date = date;
     }
 
-    public static CarryOver of(final BookLineRequest request, final Book book, final LocalDate date) {
-        if (OUTCOME.getMeaning().equals(request.getFlow())) {
-            return CarryOver.builder()
-                .money(-1 * request.getMoney())
-                .book(book)
-                .date(date)
-                .build();
-        }
-        return CarryOver.builder()
-            .money(request.getMoney())
-            .book(book)
-            .date(date)
-            .build();
-    }
-
     public static CarryOver of(final BookLine bookLine, final LocalDate date) {
         Category category = bookLine.getCategories().getLineCategory();
         if (OUTCOME.equals(category.getName())) {
@@ -76,14 +61,6 @@ public class CarryOver extends BaseEntity {
         return CarryOver.builder()
             .money(0L)
             .build();
-    }
-
-    public void update(final double updateMoney, final CategoryType categoryType) {
-        if (INCOME.equals(categoryType)) {
-            money += updateMoney;
-        } else {
-            money -= updateMoney;
-        }
     }
 
     public CarryOver delete(CategoryType categoryType) {

--- a/src/main/java/com/floney/floney/book/domain/entity/RepeatBookLine.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/RepeatBookLine.java
@@ -23,7 +23,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class RepeatBookLine extends BaseEntity {
 
-    public static final int REPEAT_YEAR = 3;
+    public static final int REPEAT_YEAR = 1;
 
     @Enumerated(value = EnumType.STRING)
     private RepeatDuration repeatDuration;

--- a/src/main/java/com/floney/floney/book/repository/AssetJdbcRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/AssetJdbcRepository.java
@@ -1,0 +1,32 @@
+package com.floney.floney.book.repository;
+
+import com.floney.floney.book.domain.entity.Asset;
+import com.floney.floney.common.constant.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AssetJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveAll(List<Asset> assets) {
+        String sql = "INSERT INTO asset (date, money, book_id,created_at,updated_at,status)" +
+            "VALUES (?,?,?,now(),now(),?) ON DUPLICATE KEY UPDATE money = money + VALUES(money), updated_at = NOW()";
+
+        jdbcTemplate.batchUpdate(sql,
+            assets,
+            assets.size(),
+            (PreparedStatement ps, Asset asset) -> {
+                ps.setString(1, asset.getDate().toString());
+                ps.setDouble(2, asset.getMoney());
+                ps.setLong(3, asset.getBook().getId());
+                ps.setString(4, Status.ACTIVE.name());
+            });
+    }
+}

--- a/src/main/java/com/floney/floney/book/repository/CarryOverJdbcRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/CarryOverJdbcRepository.java
@@ -1,0 +1,33 @@
+package com.floney.floney.book.repository;
+
+import com.floney.floney.book.domain.entity.CarryOver;
+import com.floney.floney.common.constant.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CarryOverJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveAll(List<CarryOver> bookLines) {
+        String sql = "INSERT INTO carry_over (date, money, book_id,created_at,updated_at,status)" +
+            "VALUES (?,?,?,now(),now(),?) ON DUPLICATE KEY UPDATE money = money + VALUES(money), updated_at = NOW()";
+
+        jdbcTemplate.batchUpdate(sql,
+            bookLines,
+            bookLines.size(),
+            (PreparedStatement ps, CarryOver carryOver) -> {
+                ps.setString(1, carryOver.getDate().toString());
+                ps.setDouble(2, carryOver.getMoney());
+                ps.setLong(3, carryOver.getBook().getId());
+                ps.setString(4, Status.ACTIVE.name());
+            });
+    }
+
+}

--- a/src/main/java/com/floney/floney/user/dto/security/CustomUserDetails.java
+++ b/src/main/java/com/floney/floney/user/dto/security/CustomUserDetails.java
@@ -22,11 +22,11 @@ public class CustomUserDetails implements UserDetails {
         roles.add(Role.USER);
 
         return new CustomUserDetails(
-                user,
-                roles.stream()
-                        .map(Role::getName)
-                        .map(SimpleGrantedAuthority::new)
-                        .collect(Collectors.toUnmodifiableSet())
+            user,
+            roles.stream()
+                .map(Role::getName)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toUnmodifiableSet())
         );
     }
 
@@ -69,4 +69,11 @@ public class CustomUserDetails implements UserDetails {
         return user;
     }
 
+    @Override
+    public String toString() {
+        return "CustomUserDetails{" +
+            "user=" + user.getEmail() +
+            ", authorities=" + authorities +
+            '}';
+    }
 }

--- a/src/test/java/com/floney/floney/book/domain/entity/CarryOverTest.java
+++ b/src/test/java/com/floney/floney/book/domain/entity/CarryOverTest.java
@@ -1,6 +1,7 @@
 package com.floney.floney.book.domain.entity;
 
 
+import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.fixture.*;
 import com.floney.floney.user.entity.User;
 import org.assertj.core.api.Assertions;
@@ -15,8 +16,8 @@ import java.time.LocalDate;
 public class CarryOverTest {
 
     @Nested
-    @DisplayName("getCarryOverToAdd()를 실행할 때")
-    class Describe_GetCarryOverToAdd {
+    @DisplayName("of()를 실행할 때")
+    class Describe_Of {
         User user;
         Book book;
         String bookKey;
@@ -47,7 +48,7 @@ public class CarryOverTest {
             @Test
             @DisplayName("금액이 양수인, 이월 내역이 생성된다")
             void it_return_positive_money() {
-                CarryOver carryOver = CarryOver.getCarryOverToAdd(bookLine, LocalDate.now().plusDays(1));
+                CarryOver carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
                 Assertions.assertThat(carryOver.getMoney()).isEqualTo(bookLine.getMoney());
             }
         }
@@ -68,7 +69,7 @@ public class CarryOverTest {
             @Test
             @DisplayName("금액이 음수인, 이월 내역이 생성된다")
             void it_return_negative_money() {
-                CarryOver carryOver = CarryOver.getCarryOverToAdd(bookLine, LocalDate.now().plusDays(1));
+                CarryOver carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
                 Assertions.assertThat(carryOver.getMoney()).isEqualTo(-1 * bookLine.getMoney());
             }
 
@@ -76,8 +77,8 @@ public class CarryOverTest {
     }
 
     @Nested
-    @DisplayName("getCarryOverToDelete()를 실행할 때")
-    class Describe_GetCarryOverToDelete {
+    @DisplayName("update()를 실행할 때")
+    class Describe_Update {
         User user;
         Book book;
         String bookKey;
@@ -103,13 +104,14 @@ public class CarryOverTest {
                 String incomeSubCategoryName = "급여";
                 final BookLineCategory bookLineCategory = BookLineCategoryFixture.incomeBookLineCategory(book, incomeSubCategoryName, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
-            @DisplayName("이월 금액은 음수가 된다")
-            void it_return_negative_money() {
-                Assertions.assertThat(carryOver.getMoney()).isEqualTo(-1 * bookLine.getMoney());
+            @DisplayName("이월 금액이 증가한다")
+            void it_increase_money() {
+                carryOver.update(1000, CategoryType.INCOME);
+                Assertions.assertThat(carryOver.getMoney()).isGreaterThan(bookLine.getMoney());
             }
         }
 
@@ -125,13 +127,14 @@ public class CarryOverTest {
                 String outcomeSubCategory = "식비";
                 final BookLineCategory bookLineCategory = BookLineCategoryFixture.outcomeBookLineCategory(book, outcomeSubCategory, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
-            @DisplayName("이월 금액은 양수가 된다")
-            void it_return_positive_money() {
-                Assertions.assertThat(carryOver.getMoney()).isEqualTo(bookLine.getMoney());
+            @DisplayName("이월 금액이 감소한다")
+            void it_decrease_money() {
+                carryOver.update(1000, CategoryType.OUTCOME);
+                Assertions.assertThat(carryOver.getMoney()).isLessThan(bookLine.getMoney());
             }
         }
     }
@@ -165,13 +168,14 @@ public class CarryOverTest {
                 String incomeSubCategoryName = "급여";
                 bookLineCategory = BookLineCategoryFixture.incomeBookLineCategory(book, incomeSubCategoryName, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
-            @DisplayName("이월 금액은 음수가 된다")
-            void it_return_negative_money() {
-                Assertions.assertThat(carryOver.getMoney()).isEqualTo(-1 * bookLine.getMoney());
+            @DisplayName("부호가 반대인 이월 내역이 반환된다")
+            void it_return_delete_money() {
+                CarryOver deleteCarryOver = carryOver.delete(bookLineCategory.getLineCategory().getName());
+                Assertions.assertThat(deleteCarryOver.getMoney()).isEqualTo(-1 * bookLine.getMoney());
             }
         }
 
@@ -187,13 +191,14 @@ public class CarryOverTest {
                 String outcomeSubCategory = "식비";
                 bookLineCategory = BookLineCategoryFixture.outcomeBookLineCategory(book, outcomeSubCategory, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
-            @DisplayName("이월 금액은 양수가 된다")
-            void it_return_positive_money() {
-                Assertions.assertThat(carryOver.getMoney()).isEqualTo(bookLine.getMoney());
+            @DisplayName("부호가 반대인 이월 내역이 반환된다")
+            void it_return_delete_money() {
+                CarryOver deleteCarryOver = carryOver.delete(bookLineCategory.getLineCategory().getName());
+                Assertions.assertThat(deleteCarryOver.getMoney()).isEqualTo(bookLine.getMoney());
             }
         }
 
@@ -209,13 +214,14 @@ public class CarryOverTest {
                 String transferSubCategory = "이체";
                 bookLineCategory = BookLineCategoryFixture.transferBookLineCategory(book, transferSubCategory, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
             @DisplayName("이월 금액은 변하지 않는다")
             void it_maintain_money() {
-                Assertions.assertThat(carryOver.getMoney()).isEqualTo(bookLine.getMoney());
+                CarryOver deleteCarryOver = carryOver.delete(bookLineCategory.getLineCategory().getName());
+                Assertions.assertThat(deleteCarryOver.getMoney()).isEqualTo(bookLine.getMoney());
             }
         }
     }

--- a/src/test/java/com/floney/floney/book/domain/entity/CarryOverTest.java
+++ b/src/test/java/com/floney/floney/book/domain/entity/CarryOverTest.java
@@ -1,7 +1,6 @@
 package com.floney.floney.book.domain.entity;
 
 
-import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.fixture.*;
 import com.floney.floney.user.entity.User;
 import org.assertj.core.api.Assertions;
@@ -16,8 +15,8 @@ import java.time.LocalDate;
 public class CarryOverTest {
 
     @Nested
-    @DisplayName("of()를 실행할 때")
-    class Describe_Of {
+    @DisplayName("getCarryOverToAdd()를 실행할 때")
+    class Describe_GetCarryOverToAdd {
         User user;
         Book book;
         String bookKey;
@@ -48,7 +47,7 @@ public class CarryOverTest {
             @Test
             @DisplayName("금액이 양수인, 이월 내역이 생성된다")
             void it_return_positive_money() {
-                CarryOver carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
+                CarryOver carryOver = CarryOver.getCarryOverToAdd(bookLine, LocalDate.now().plusDays(1));
                 Assertions.assertThat(carryOver.getMoney()).isEqualTo(bookLine.getMoney());
             }
         }
@@ -69,7 +68,7 @@ public class CarryOverTest {
             @Test
             @DisplayName("금액이 음수인, 이월 내역이 생성된다")
             void it_return_negative_money() {
-                CarryOver carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
+                CarryOver carryOver = CarryOver.getCarryOverToAdd(bookLine, LocalDate.now().plusDays(1));
                 Assertions.assertThat(carryOver.getMoney()).isEqualTo(-1 * bookLine.getMoney());
             }
 
@@ -77,8 +76,8 @@ public class CarryOverTest {
     }
 
     @Nested
-    @DisplayName("update()를 실행할 때")
-    class Describe_Update {
+    @DisplayName("getCarryOverToDelete()를 실행할 때")
+    class Describe_GetCarryOverToDelete {
         User user;
         Book book;
         String bookKey;
@@ -104,14 +103,13 @@ public class CarryOverTest {
                 String incomeSubCategoryName = "급여";
                 final BookLineCategory bookLineCategory = BookLineCategoryFixture.incomeBookLineCategory(book, incomeSubCategoryName, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
-            @DisplayName("이월 금액이 증가한다")
-            void it_increase_money() {
-                carryOver.update(1000, CategoryType.INCOME);
-                Assertions.assertThat(carryOver.getMoney()).isGreaterThan(bookLine.getMoney());
+            @DisplayName("이월 금액은 음수가 된다")
+            void it_return_negative_money() {
+                Assertions.assertThat(carryOver.getMoney()).isEqualTo(-1 * bookLine.getMoney());
             }
         }
 
@@ -127,14 +125,13 @@ public class CarryOverTest {
                 String outcomeSubCategory = "식비";
                 final BookLineCategory bookLineCategory = BookLineCategoryFixture.outcomeBookLineCategory(book, outcomeSubCategory, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
-            @DisplayName("이월 금액이 감소한다")
-            void it_decrease_money() {
-                carryOver.update(1000, CategoryType.OUTCOME);
-                Assertions.assertThat(carryOver.getMoney()).isLessThan(bookLine.getMoney());
+            @DisplayName("이월 금액은 양수가 된다")
+            void it_return_positive_money() {
+                Assertions.assertThat(carryOver.getMoney()).isEqualTo(bookLine.getMoney());
             }
         }
     }
@@ -168,14 +165,13 @@ public class CarryOverTest {
                 String incomeSubCategoryName = "급여";
                 bookLineCategory = BookLineCategoryFixture.incomeBookLineCategory(book, incomeSubCategoryName, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
-            @DisplayName("이월 금액이 감소한다")
-            void it_decrease_money() {
-                carryOver.delete(1000, bookLineCategory);
-                Assertions.assertThat(carryOver.getMoney()).isLessThan(bookLine.getMoney());
+            @DisplayName("이월 금액은 음수가 된다")
+            void it_return_negative_money() {
+                Assertions.assertThat(carryOver.getMoney()).isEqualTo(-1 * bookLine.getMoney());
             }
         }
 
@@ -191,14 +187,13 @@ public class CarryOverTest {
                 String outcomeSubCategory = "식비";
                 bookLineCategory = BookLineCategoryFixture.outcomeBookLineCategory(book, outcomeSubCategory, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
-            @DisplayName("이월 금액이 증가한다")
-            void it_decrease_money() {
-                carryOver.delete(1000, bookLineCategory);
-                Assertions.assertThat(carryOver.getMoney()).isGreaterThan(-1 * bookLine.getMoney());
+            @DisplayName("이월 금액은 양수가 된다")
+            void it_return_positive_money() {
+                Assertions.assertThat(carryOver.getMoney()).isEqualTo(bookLine.getMoney());
             }
         }
 
@@ -214,13 +209,12 @@ public class CarryOverTest {
                 String transferSubCategory = "이체";
                 bookLineCategory = BookLineCategoryFixture.transferBookLineCategory(book, transferSubCategory, assetSubCategoryName);
                 bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
+                carryOver = CarryOver.getCarryOverToDelete(bookLine, LocalDate.now().plusDays(1));
             }
 
             @Test
             @DisplayName("이월 금액은 변하지 않는다")
             void it_maintain_money() {
-                carryOver.delete(1000, bookLineCategory);
                 Assertions.assertThat(carryOver.getMoney()).isEqualTo(bookLine.getMoney());
             }
         }

--- a/src/test/java/com/floney/floney/book/domain/entity/CarryOverTest.java
+++ b/src/test/java/com/floney/floney/book/domain/entity/CarryOverTest.java
@@ -1,7 +1,6 @@
 package com.floney.floney.book.domain.entity;
 
 
-import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.fixture.*;
 import com.floney.floney.user.entity.User;
 import org.assertj.core.api.Assertions;
@@ -73,69 +72,6 @@ public class CarryOverTest {
                 Assertions.assertThat(carryOver.getMoney()).isEqualTo(-1 * bookLine.getMoney());
             }
 
-        }
-    }
-
-    @Nested
-    @DisplayName("update()를 실행할 때")
-    class Describe_Update {
-        User user;
-        Book book;
-        String bookKey;
-        BookUser bookUser;
-        String assetSubCategoryName = "자산";
-
-        @BeforeEach
-        void init() {
-            user = UserFixture.emailUser();
-            book = BookFixture.createBook();
-            bookKey = book.getBookKey();
-            bookUser = BookUserFixture.createBookUser(book, user);
-        }
-
-        @Nested
-        @DisplayName("수입 이월 내역이 주어지면")
-        class Context_With_IncomeMoney {
-            BookLine bookLine;
-            CarryOver carryOver;
-
-            @BeforeEach
-            void init() {
-                String incomeSubCategoryName = "급여";
-                final BookLineCategory bookLineCategory = BookLineCategoryFixture.incomeBookLineCategory(book, incomeSubCategoryName, assetSubCategoryName);
-                bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
-            }
-
-            @Test
-            @DisplayName("이월 금액이 증가한다")
-            void it_increase_money() {
-                carryOver.update(1000, CategoryType.INCOME);
-                Assertions.assertThat(carryOver.getMoney()).isGreaterThan(bookLine.getMoney());
-            }
-        }
-
-        @Nested
-        @DisplayName("지출 이월 내역이 주어지면")
-        class Context_With_OutcomeMoney {
-
-            CarryOver carryOver;
-            BookLine bookLine;
-
-            @BeforeEach
-            void init() {
-                String outcomeSubCategory = "식비";
-                final BookLineCategory bookLineCategory = BookLineCategoryFixture.outcomeBookLineCategory(book, outcomeSubCategory, assetSubCategoryName);
-                bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
-                carryOver = CarryOver.of(bookLine, LocalDate.now().plusDays(1));
-            }
-
-            @Test
-            @DisplayName("이월 금액이 감소한다")
-            void it_decrease_money() {
-                carryOver.update(1000, CategoryType.OUTCOME);
-                Assertions.assertThat(carryOver.getMoney()).isLessThan(bookLine.getMoney());
-            }
         }
     }
 

--- a/src/test/java/com/floney/floney/book/service/AssetServiceTest.java
+++ b/src/test/java/com/floney/floney/book/service/AssetServiceTest.java
@@ -5,6 +5,7 @@ import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookLine;
 import com.floney.floney.book.domain.entity.BookLineCategory;
 import com.floney.floney.book.domain.entity.BookUser;
+import com.floney.floney.book.repository.AssetJdbcRepository;
 import com.floney.floney.book.repository.analyze.AssetRepository;
 import com.floney.floney.fixture.*;
 import com.floney.floney.user.entity.User;
@@ -18,8 +19,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.List;
 
-import static com.floney.floney.analyze.service.AssetServiceImpl.SAVE_ASSET_DURATION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -32,6 +33,9 @@ public class AssetServiceTest {
 
     @Mock
     private AssetRepository assetRepository;
+
+    @Mock
+    private AssetJdbcRepository assetJdbcRepository;
 
     @Nested
     @DisplayName("addAssetOf()를 실행할 때")
@@ -66,7 +70,7 @@ public class AssetServiceTest {
             @DisplayName("자산이 업데이트 된다")
             void it_update_asset() {
                 assetService.addAssetOf(bookLine);
-                verify(assetRepository, times(SAVE_ASSET_DURATION)).upsertMoneyByDateAndBook(any(LocalDate.class), any(Book.class), any(Double.class));
+                verify(assetJdbcRepository, times(1)).saveAll(any(List.class));
             }
         }
 
@@ -84,7 +88,7 @@ public class AssetServiceTest {
             @DisplayName("자산이 업데이트 된다")
             void it_update_asset() {
                 assetService.addAssetOf(bookLine);
-                verify(assetRepository, times(SAVE_ASSET_DURATION)).upsertMoneyByDateAndBook(any(LocalDate.class), any(Book.class), any(Double.class));
+                verify(assetJdbcRepository, times(1)).saveAll(any(List.class));
             }
         }
 
@@ -102,7 +106,7 @@ public class AssetServiceTest {
             @DisplayName("자산이 업데이트 되지 않는다")
             void it_didnt_update_asset() {
                 assetService.addAssetOf(bookLine);
-                verify(assetRepository, never()).upsertMoneyByDateAndBook(any(LocalDate.class), any(Book.class), any(Double.class));
+                verify(assetJdbcRepository, never()).saveAll(any(List.class));
             }
         }
     }

--- a/src/test/java/com/floney/floney/book/service/CarryOverServiceTest.java
+++ b/src/test/java/com/floney/floney/book/service/CarryOverServiceTest.java
@@ -5,8 +5,8 @@ import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookLine;
 import com.floney.floney.book.domain.entity.BookLineCategory;
 import com.floney.floney.book.domain.entity.BookUser;
+import com.floney.floney.book.repository.BookLineRepository;
 import com.floney.floney.book.repository.CarryOverJdbcRepository;
-import com.floney.floney.book.repository.analyze.CarryOverRepository;
 import com.floney.floney.fixture.*;
 import com.floney.floney.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,11 +17,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @DisplayName("단위 테스트 : CarryOverService")
@@ -32,7 +35,7 @@ public class CarryOverServiceTest {
     private CarryOverServiceImpl carryOverService;
 
     @Mock
-    private CarryOverRepository carryOverRepository;
+    private BookLineRepository bookLineRepository;
 
     @Mock
     private CarryOverJdbcRepository carryOverJdbcRepository;
@@ -110,6 +113,95 @@ public class CarryOverServiceTest {
             @DisplayName("이월 내역이 생성 되지 않는다")
             void it_didnt_create_carryOver() {
                 carryOverService.createCarryOver(bookLine);
+                verify(carryOverJdbcRepository, never()).saveAll(any(List.class));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteCarryOver()를 실행할 때")
+    class Describe_DeleteCarryOver {
+        User user;
+        Book book;
+        String bookKey;
+        BookUser bookUser;
+        String assetSubCategoryName = "자산";
+
+        @BeforeEach()
+        void init() {
+            user = UserFixture.emailUser();
+            book = BookFixture.createBook();
+            book.changeCarryOverStatus(true);
+
+            bookKey = book.getBookKey();
+            bookUser = BookUserFixture.createBookUser(book, user);
+        }
+
+        @Nested
+        @DisplayName("카테고리가 수입인 가계부 내역이 주어지면")
+        class Context_With_IncomeBookLine {
+            long bookLineId;
+
+            @BeforeEach
+            void init() {
+                String incomeSubCategoryName = "급여";
+                final BookLineCategory bookLineCategory = BookLineCategoryFixture.incomeBookLineCategory(book, incomeSubCategoryName, assetSubCategoryName);
+                BookLine bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
+                ReflectionTestUtils.setField(bookLine, "id", 1L);
+                bookLineId = bookLine.getId();
+                given(bookLineRepository.findById(bookLineId)).willReturn(Optional.of(bookLine));
+            }
+
+            @Test
+            @DisplayName("이월 내역이 생성 된다")
+            void it_create_carryOver() {
+                carryOverService.deleteCarryOver(bookLineId);
+                verify(carryOverJdbcRepository, times(1)).saveAll(any(List.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("카테고리가 지출인 가계부 내역이 주어지면")
+        class Context_With_OutcomeBookLine {
+            long bookLineId;
+
+            @BeforeEach
+            void init() {
+                String outcomeSubCategoryName = "식비";
+                final BookLineCategory bookLineCategory = BookLineCategoryFixture.outcomeBookLineCategory(book, outcomeSubCategoryName, assetSubCategoryName);
+                BookLine bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
+                ReflectionTestUtils.setField(bookLine, "id", 1L);
+                bookLineId = bookLine.getId();
+                given(bookLineRepository.findById(bookLineId)).willReturn(Optional.of(bookLine));
+            }
+
+            @Test
+            @DisplayName("이월 내역이 생성 된다")
+            void it_create_carryOver() {
+                carryOverService.deleteCarryOver(bookLineId);
+                verify(carryOverJdbcRepository, times(1)).saveAll(any(List.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("카테고리가 이체인 가계부 내역이 주어지면")
+        class Context_With_TransferBookLine {
+            long bookLineId;
+
+            @BeforeEach
+            void init() {
+                String transferSubCategoryName = "이체";
+                final BookLineCategory bookLineCategory = BookLineCategoryFixture.transferBookLineCategory(book, transferSubCategoryName, assetSubCategoryName);
+                BookLine bookLine = BookLineFixture.createWithDate(book, bookUser, bookLineCategory, LocalDate.now());
+                ReflectionTestUtils.setField(bookLine, "id", 1L);
+                bookLineId = bookLine.getId();
+                given(bookLineRepository.findById(bookLineId)).willReturn(Optional.of(bookLine));
+            }
+
+            @Test
+            @DisplayName("이월 내역이 생성 되지 않는다")
+            void it_didnt_create_carryOver() {
+                carryOverService.deleteCarryOver(bookLineId);
                 verify(carryOverJdbcRepository, never()).saveAll(any(List.class));
             }
         }

--- a/src/test/java/com/floney/floney/book/service/CarryOverServiceTest.java
+++ b/src/test/java/com/floney/floney/book/service/CarryOverServiceTest.java
@@ -5,6 +5,7 @@ import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookLine;
 import com.floney.floney.book.domain.entity.BookLineCategory;
 import com.floney.floney.book.domain.entity.BookUser;
+import com.floney.floney.book.repository.CarryOverJdbcRepository;
 import com.floney.floney.book.repository.analyze.CarryOverRepository;
 import com.floney.floney.fixture.*;
 import com.floney.floney.user.entity.User;
@@ -18,8 +19,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.List;
 
-import static com.floney.floney.analyze.service.CarryOverServiceImpl.SAVE_CARRY_OVER_DURATION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -32,6 +33,9 @@ public class CarryOverServiceTest {
 
     @Mock
     private CarryOverRepository carryOverRepository;
+
+    @Mock
+    private CarryOverJdbcRepository carryOverJdbcRepository;
 
     @Nested
     @DisplayName("createCarryOver()를 실행할 때")
@@ -66,7 +70,7 @@ public class CarryOverServiceTest {
             @DisplayName("이월 내역이 생성 된다")
             void it_create_carryOver() {
                 carryOverService.createCarryOver(bookLine);
-                verify(carryOverRepository, times(SAVE_CARRY_OVER_DURATION)).upsertMoneyByDateAndBook(any(LocalDate.class), any(Book.class), any(Double.class));
+                verify(carryOverJdbcRepository, times(1)).saveAll(any(List.class));
             }
         }
 
@@ -86,7 +90,7 @@ public class CarryOverServiceTest {
             @DisplayName("이월 내역이 생성 된다")
             void it_create_carryOver() {
                 carryOverService.createCarryOver(bookLine);
-                verify(carryOverRepository, times(SAVE_CARRY_OVER_DURATION)).upsertMoneyByDateAndBook(any(LocalDate.class), any(Book.class), any(Double.class));
+                verify(carryOverJdbcRepository, times(1)).saveAll(any(List.class));
             }
         }
 
@@ -106,7 +110,7 @@ public class CarryOverServiceTest {
             @DisplayName("이월 내역이 생성 되지 않는다")
             void it_didnt_create_carryOver() {
                 carryOverService.createCarryOver(bookLine);
-                verify(carryOverRepository, never()).upsertMoneyByDateAndBook(any(LocalDate.class), any(Book.class), any(Double.class));
+                verify(carryOverJdbcRepository, never()).saveAll(any(List.class));
             }
         }
     }


### PR DESCRIPTION
## 📌 개요

반복 내역 성능 개선

## ✅ 개발 내용

 **_EVERYDAY 로 가계부 내역 추가 시, 수치 확인 후 공유 부탁드립니다_**

- 우선 통과 안하는 테스트는 성능 개선 검토 후 통과하게 만들겠습니다
- 자산, 이월 설정 수치 잘 업데이트 되는거 확인했습니다.
- yml에서 mysql에 `?&rewriteBatchedStatements=true` 설정 해주셔야합니다 
ex. `url: jdbc:mysql://localhost:3306/floney_local?&rewriteBatchedStatements=true`
- dev,prod는 제가 `?&rewriteBatchedStatements=true` 해놨습니다
- 작디 작은 램 부족도 문제인것 같습니다
