### PR TITLE
#416 fix: 카테고리 삭제 시 연관 반복 내역도 삭제

### DIFF
--- a/src/main/java/com/floney/floney/book/repository/RepeatBookLineCustomRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/RepeatBookLineCustomRepository.java
@@ -1,11 +1,19 @@
 package com.floney.floney.book.repository;
 
+import com.floney.floney.book.domain.category.entity.Subcategory;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookUser;
+import com.floney.floney.book.domain.entity.RepeatBookLine;
+
+import java.util.List;
 
 public interface RepeatBookLineCustomRepository {
 
     void inactiveAllByBook(Book book);
 
     void inactiveAllByBookUser(BookUser targetBookUser);
+
+    void inactiveAllBySubcategory(Subcategory subcategory);
+
+    List<RepeatBookLine> findAllBySubcategory(Subcategory subcategory);
 }

--- a/src/main/java/com/floney/floney/book/repository/RepeatBookLineCustomRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/RepeatBookLineCustomRepository.java
@@ -3,9 +3,6 @@ package com.floney.floney.book.repository;
 import com.floney.floney.book.domain.category.entity.Subcategory;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookUser;
-import com.floney.floney.book.domain.entity.RepeatBookLine;
-
-import java.util.List;
 
 public interface RepeatBookLineCustomRepository {
 
@@ -14,6 +11,4 @@ public interface RepeatBookLineCustomRepository {
     void inactiveAllByBookUser(BookUser targetBookUser);
 
     void inactiveAllBySubcategory(Subcategory subcategory);
-
-    List<RepeatBookLine> findAllBySubcategory(Subcategory subcategory);
 }

--- a/src/main/java/com/floney/floney/book/repository/RepeatBookLineRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/RepeatBookLineRepository.java
@@ -1,13 +1,10 @@
 package com.floney.floney.book.repository;
 
 import com.floney.floney.book.domain.category.entity.Category;
-import com.floney.floney.book.domain.category.entity.Subcategory;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.RepeatBookLine;
 import com.floney.floney.common.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,11 +13,5 @@ public interface RepeatBookLineRepository extends JpaRepository<RepeatBookLine, 
 
     List<RepeatBookLine> findAllByBookAndStatusAndLineCategory(Book book, Status status, Category category);
 
-    Optional<RepeatBookLine> findByIdAndStatus(long repeatLineId, Status status);
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE RepeatBookLine rbl SET rbl.status = 'INACTIVE' " +
-        "WHERE (rbl.lineSubcategory = :subcategory OR rbl.assetSubcategory = :subcategory) " +
-        "AND rbl.status = 'ACTIVE'")
-    void inactiveAllBySubcategory(Subcategory subcategory);
+    Optional<RepeatBookLine> findByIdAndStatus(long id, Status status);
 }

--- a/src/main/java/com/floney/floney/book/repository/RepeatBookLineRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/RepeatBookLineRepository.java
@@ -1,16 +1,26 @@
 package com.floney.floney.book.repository;
 
 import com.floney.floney.book.domain.category.entity.Category;
+import com.floney.floney.book.domain.category.entity.Subcategory;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.RepeatBookLine;
 import com.floney.floney.common.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface RepeatBookLineRepository extends JpaRepository<RepeatBookLine, Long> {
+
     List<RepeatBookLine> findAllByBookAndStatusAndLineCategory(Book book, Status status, Category category);
 
     Optional<RepeatBookLine> findByIdAndStatus(long repeatLineId, Status status);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE RepeatBookLine rbl SET rbl.status = 'INACTIVE' " +
+        "WHERE (rbl.lineSubcategory = :subcategory OR rbl.assetSubcategory = :subcategory) " +
+        "AND rbl.status = 'ACTIVE'")
+    void inactiveAllBySubcategory(Subcategory subcategory);
 }

--- a/src/main/java/com/floney/floney/book/repository/RepeatBookLineRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/RepeatBookLineRepositoryImpl.java
@@ -4,7 +4,6 @@ package com.floney.floney.book.repository;
 import com.floney.floney.book.domain.category.entity.Subcategory;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookUser;
-import com.floney.floney.book.domain.entity.RepeatBookLine;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -14,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static com.floney.floney.book.domain.entity.QBookUser.bookUser;
 import static com.floney.floney.book.domain.entity.QRepeatBookLine.repeatBookLine;
@@ -83,21 +81,5 @@ public class RepeatBookLineRepositoryImpl implements RepeatBookLineCustomReposit
             .execute();
 
         entityManager.clear();
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<RepeatBookLine> findAllBySubcategory(final Subcategory subcategory) {
-        return jpaQueryFactory.selectFrom(repeatBookLine)
-            .where(
-                repeatBookLine.lineSubcategory.eq(subcategory)
-                    .or(repeatBookLine.assetSubcategory.eq(subcategory))
-            )
-            .where(
-                repeatBookLine.status.eq(ACTIVE),
-                repeatBookLine.lineSubcategory.status.eq(ACTIVE),
-                repeatBookLine.assetSubcategory.status.eq(ACTIVE)
-            )
-            .fetch();
     }
 }

--- a/src/main/java/com/floney/floney/book/service/category/CategoryServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/category/CategoryServiceImpl.java
@@ -9,6 +9,7 @@ import com.floney.floney.book.dto.request.CreateCategoryRequest;
 import com.floney.floney.book.dto.request.DeleteCategoryRequest;
 import com.floney.floney.book.dto.response.CreateCategoryResponse;
 import com.floney.floney.book.repository.BookRepository;
+import com.floney.floney.book.repository.RepeatBookLineRepository;
 import com.floney.floney.book.repository.category.BookLineCategoryRepository;
 import com.floney.floney.book.repository.category.CategoryRepository;
 import com.floney.floney.book.repository.category.SubcategoryRepository;
@@ -34,6 +35,7 @@ public class CategoryServiceImpl implements CategoryService {
     private final BookRepository bookRepository;
     private final BookLineService bookLineService;
     private final BookLineCategoryRepository bookLineCategoryRepository;
+    private final RepeatBookLineRepository repeatBookLineRepository;
 
     @Override
     public CreateCategoryResponse createSubcategory(final String bookKey, final CreateCategoryRequest request) {
@@ -68,6 +70,8 @@ public class CategoryServiceImpl implements CategoryService {
                 // 예산, 자산, 이월 설정 관련 내역 모두 삭제
                 bookLineService.deleteLine(bookLine.getId());
             });
+
+        repeatBookLineRepository.inactiveAllBySubcategory(subcategory);
 
         subcategory.inactive();
     }

--- a/src/test/java/com/floney/floney/acceptance/fixture/BookApiFixture.java
+++ b/src/test/java/com/floney/floney/acceptance/fixture/BookApiFixture.java
@@ -4,7 +4,6 @@ import com.floney.floney.book.domain.RepeatDuration;
 import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.book.dto.response.CreateBookResponse;
 import com.floney.floney.book.dto.response.RepeatBookLineResponse;
-import com.floney.floney.book.dto.response.TotalDayLinesResponse;
 import io.restassured.RestAssured;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -59,19 +58,6 @@ public class BookApiFixture {
             .extract().as(RepeatBookLineResponse[].class);
     }
 
-    public static TotalDayLinesResponse getBookLineByDay(final String accessToken,
-                                                         final String date,
-                                                         final String bookKey) {
-        return RestAssured.given()
-            .auth().oauth2(accessToken)
-            .param("bookKey", bookKey)
-            .param("date", date)
-            .when().get("/books/days")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract().as(TotalDayLinesResponse.class);
-    }
-
     public static long createBookLine(final String accessToken,
                                       final String bookKey,
                                       final String lineCategoryName,
@@ -121,6 +107,35 @@ public class BookApiFixture {
                     "repeatDuration": "NONE"
                 }
                 """.formatted(bookKey, lineCategoryName, assetSubcategoryName, lineSubcategoryName, date))
+            .when().post("/books/lines")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract()
+            .jsonPath()
+            .getLong("id");
+    }
+
+    public static long createBookLine(final String accessToken,
+                                      final String bookKey,
+                                      final String lineCategoryName,
+                                      final String lineSubcategoryName,
+                                      final String assetSubcategoryName,
+                                      final RepeatDuration repeatDuration) {
+        return RestAssured.given()
+            .auth().oauth2(accessToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body("""
+                {
+                    "bookKey": "%s",
+                    "money": 1000,
+                    "flow": "%s",
+                    "asset": "%s",
+                    "line": "%s",
+                    "lineDate": "2000-01-01",
+                    "except": false,
+                    "repeatDuration": "%s"
+                }
+                """.formatted(bookKey, lineCategoryName, assetSubcategoryName, lineSubcategoryName, repeatDuration))
             .when().post("/books/lines")
             .then()
             .statusCode(HttpStatus.CREATED.value())

--- a/src/test/java/com/floney/floney/book/repository/RepeatBookLineRepositoryTest.java
+++ b/src/test/java/com/floney/floney/book/repository/RepeatBookLineRepositoryTest.java
@@ -25,7 +25,7 @@ import static com.floney.floney.book.domain.RepeatDuration.MONTH;
 import static com.floney.floney.book.domain.category.CategoryType.ASSET;
 import static com.floney.floney.book.domain.category.CategoryType.INCOME;
 import static com.floney.floney.common.constant.Status.ACTIVE;
-import static com.floney.floney.fixture.RepeatBookLineFixture.createRepeatBookLine;
+import static com.floney.floney.fixture.RepeatBookLineFixture.repeatBookLine;
 import static com.floney.floney.fixture.SubcategoryFixture.createSubcategory;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -70,8 +70,8 @@ public class RepeatBookLineRepositoryTest {
                 final BookUser bookUser = bookUserRepository.save(BookUser.of(user, book));
                 category = categoryRepository.findByType(INCOME).orElseThrow();
 
-                final RepeatBookLine repeatBookLine = createRepeatBookLine(category, bookUser, EVERYDAY);
-                final RepeatBookLine repeatBookLine2 = createRepeatBookLine(category, bookUser, MONTH);
+                final RepeatBookLine repeatBookLine = repeatBookLine(category, bookUser, EVERYDAY);
+                final RepeatBookLine repeatBookLine2 = repeatBookLine(category, bookUser, MONTH);
 
                 repeatBookLineRepository.save(repeatBookLine);
                 repeatBookLineRepository.save(repeatBookLine2);
@@ -108,8 +108,8 @@ public class RepeatBookLineRepositoryTest {
                 bookUser = bookUserRepository.save(BookUser.of(user, book));
                 category = categoryRepository.findByType(INCOME).orElseThrow();
 
-                final RepeatBookLine repeatBookLine = createRepeatBookLine(category, bookUser, EVERYDAY);
-                final RepeatBookLine repeatBookLine2 = createRepeatBookLine(category, bookUser, MONTH);
+                final RepeatBookLine repeatBookLine = repeatBookLine(category, bookUser, EVERYDAY);
+                final RepeatBookLine repeatBookLine2 = repeatBookLine(category, bookUser, MONTH);
 
                 repeatBookLineRepository.save(repeatBookLine);
                 repeatBookLineRepository.save(repeatBookLine2);

--- a/src/test/java/com/floney/floney/book/repository/RepeatBookLineRepositoryTest.java
+++ b/src/test/java/com/floney/floney/book/repository/RepeatBookLineRepositoryTest.java
@@ -25,7 +25,7 @@ import static com.floney.floney.common.constant.Status.ACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QueryDslTest
-@DisplayName("단위 테스트: RepeatBookLineRepositoryTest")
+@DisplayName("단위 테스트: RepeatBookLineRepository")
 public class RepeatBookLineRepositoryTest {
 
     @Autowired
@@ -70,8 +70,8 @@ public class RepeatBookLineRepositoryTest {
             }
 
             @Test
-            @DisplayName("반복 내역을 모두 비활성화 시킨다")
-            void it_inactive_all() {
+            @DisplayName("반복 내역을 모두 비활성화 시킨다.")
+            void it_inactivates_all() {
                 repeatBookLineRepository.inactiveAllByBook(book);
                 assertThat(repeatBookLineRepository.findAllByBookAndStatusAndLineCategory(book, ACTIVE, category))
                     .isEmpty();
@@ -84,7 +84,7 @@ public class RepeatBookLineRepositoryTest {
     class Describe_InactiveAllByBookUser {
 
         @Nested
-        @DisplayName("반복내역이 존재하는 경우")
+        @DisplayName("반복 내역이 존재하는 경우")
         class Context_With_RepeatBookLine {
 
             Book book;
@@ -107,8 +107,8 @@ public class RepeatBookLineRepositoryTest {
             }
 
             @Test
-            @DisplayName("반복 내역을 모두 비활성화 시킨다")
-            void it_inactive_all() {
+            @DisplayName("반복 내역을 모두 비활성화 시킨다.")
+            void it_inactivates_all() {
                 repeatBookLineRepository.inactiveAllByBookUser(bookUser);
                 assertThat(repeatBookLineRepository.findAllByBookAndStatusAndLineCategory(book, ACTIVE, category))
                     .isEmpty();

--- a/src/test/java/com/floney/floney/fixture/RepeatBookLineFixture.java
+++ b/src/test/java/com/floney/floney/fixture/RepeatBookLineFixture.java
@@ -3,6 +3,7 @@ package com.floney.floney.fixture;
 import com.floney.floney.book.domain.RepeatDuration;
 import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.book.domain.category.entity.Category;
+import com.floney.floney.book.domain.category.entity.Subcategory;
 import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.entity.BookUser;
 import com.floney.floney.book.domain.entity.RepeatBookLine;
@@ -11,8 +12,11 @@ import java.time.LocalDate;
 
 public class RepeatBookLineFixture {
 
-    public static RepeatBookLine createRepeatBookLine(Category category, BookUser bookUser, RepeatDuration repeatDuration) {
-        Book book = bookUser.getBook();
+    public static RepeatBookLine createRepeatBookLine(final Category category,
+                                                      final BookUser bookUser,
+                                                      final RepeatDuration repeatDuration) {
+        final Book book = bookUser.getBook();
+        
         return RepeatBookLine.builder()
             .lineDate(LocalDate.now())
             .lineCategory(category)
@@ -21,6 +25,22 @@ public class RepeatBookLineFixture {
             .money(1000.0)
             .repeatDuration(repeatDuration)
             .book(book)
+            .writer(bookUser)
+            .build();
+    }
+
+    public static RepeatBookLine repeatBookLine(final RepeatDuration repeatDuration,
+                                                final BookUser bookUser,
+                                                final Subcategory lineSubcategory,
+                                                final Subcategory assetSubcategory) {
+        return RepeatBookLine.builder()
+            .lineDate(LocalDate.now())
+            .lineCategory(lineSubcategory.getParent())
+            .lineSubcategory(lineSubcategory)
+            .assetSubcategory(assetSubcategory)
+            .money(1000.0)
+            .repeatDuration(repeatDuration)
+            .book(bookUser.getBook())
             .writer(bookUser)
             .build();
     }

--- a/src/test/java/com/floney/floney/fixture/RepeatBookLineFixture.java
+++ b/src/test/java/com/floney/floney/fixture/RepeatBookLineFixture.java
@@ -12,11 +12,11 @@ import java.time.LocalDate;
 
 public class RepeatBookLineFixture {
 
-    public static RepeatBookLine createRepeatBookLine(final Category category,
-                                                      final BookUser bookUser,
-                                                      final RepeatDuration repeatDuration) {
+    public static RepeatBookLine repeatBookLine(final Category category,
+                                                final BookUser bookUser,
+                                                final RepeatDuration repeatDuration) {
         final Book book = bookUser.getBook();
-        
+
         return RepeatBookLine.builder()
             .lineDate(LocalDate.now())
             .lineCategory(category)


### PR DESCRIPTION
## 📌 개요

카테고리 삭제 시 연관 반복 내역도 삭제한다.
(현재 반복 내역이 1년치만 생성되어 큰 성능 저하 없음. 이후 반복 내역 성능 개선 때 같이 개선하면 좋을 것 같습니다.)

## ✅ 개발 내용

- 카테고리 삭제 시 연관 반복 내역도 삭제
