### PR TITLE
#431 fix : 예산 조회 시, ACTIVE만 조회 조건 추가

### DIFF
--- a/src/main/java/com/floney/floney/book/repository/analyze/BudgetCustomRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/analyze/BudgetCustomRepositoryImpl.java
@@ -50,7 +50,8 @@ public class BudgetCustomRepositoryImpl implements BudgetCustomRepository {
             .innerJoin(budget.book, book)
             .where(
                 book.bookKey.eq(bookKey),
-                budget.date.between(duration.getStartDate(), duration.getEndDate())
+                budget.date.between(duration.getStartDate(), duration.getEndDate()),
+                budget.status.eq(ACTIVE)
             )
             .fetch();
     }


### PR DESCRIPTION
## 📌 개요

가계부 초기화 후 에산이 초기화 되지 않았음

## ✅ 개발 내용

- DB에서 초기화는 정상 작동
- 조회 할 떄, ACTIVE만 조회하는 조건이 누락 돼, 해당 부분 추가함
