### PR TITLE
#439 feat: 즐겨찾기 추가 구현

### DIFF
--- a/src/main/java/com/floney/floney/book/controller/FavoriteController.java
+++ b/src/main/java/com/floney/floney/book/controller/FavoriteController.java
@@ -2,18 +2,24 @@ package com.floney.floney.book.controller;
 
 import com.floney.floney.book.dto.request.FavoriteCreateRequest;
 import com.floney.floney.book.dto.response.FavoriteResponse;
+import com.floney.floney.book.service.FavoriteService;
+import com.floney.floney.user.dto.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class FavoriteController {
 
+    private final FavoriteService favoriteService;
+
     @PostMapping("/books/{key}/favorites")
     @ResponseStatus(HttpStatus.CREATED)
     public FavoriteResponse createFavorite(@PathVariable("key") final String bookKey,
+                                           @AuthenticationPrincipal final CustomUserDetails userDetails,
                                            @RequestBody final FavoriteCreateRequest request) {
-        return null;
+        return favoriteService.createFavorite(bookKey, userDetails.getUsername(), request);
     }
 }

--- a/src/main/java/com/floney/floney/book/controller/FavoriteController.java
+++ b/src/main/java/com/floney/floney/book/controller/FavoriteController.java
@@ -1,0 +1,19 @@
+package com.floney.floney.book.controller;
+
+import com.floney.floney.book.dto.request.FavoriteCreateRequest;
+import com.floney.floney.book.dto.response.FavoriteResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    @PostMapping("/books/{key}/favorites")
+    @ResponseStatus(HttpStatus.CREATED)
+    public FavoriteResponse createFavorite(@PathVariable("key") final String bookKey,
+                                           @RequestBody final FavoriteCreateRequest request) {
+        return null;
+    }
+}

--- a/src/main/java/com/floney/floney/book/controller/FavoriteController.java
+++ b/src/main/java/com/floney/floney/book/controller/FavoriteController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 public class FavoriteController {
@@ -19,7 +21,7 @@ public class FavoriteController {
     @ResponseStatus(HttpStatus.CREATED)
     public FavoriteResponse createFavorite(@PathVariable("key") final String bookKey,
                                            @AuthenticationPrincipal final CustomUserDetails userDetails,
-                                           @RequestBody final FavoriteCreateRequest request) {
+                                           @RequestBody @Valid final FavoriteCreateRequest request) {
         return favoriteService.createFavorite(bookKey, userDetails.getUsername(), request);
     }
 }

--- a/src/main/java/com/floney/floney/book/domain/entity/Book.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/Book.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 public class Book extends BaseEntity {
 
     private static final double DEFAULT = 0.0;
+    public static final int FAVORITE_MAX_SIZE = 10;
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/com/floney/floney/book/domain/entity/BookLine.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/BookLine.java
@@ -56,7 +56,8 @@ public class BookLine extends BaseEntity {
                      final Double money,
                      final LocalDate lineDate,
                      final String description,
-                     final Boolean exceptStatus, final RepeatBookLine repeatBookLine) {
+                     final Boolean exceptStatus,
+                     final RepeatBookLine repeatBookLine) {
 
         categories.setBookLine(this);
 

--- a/src/main/java/com/floney/floney/book/domain/favorite/Favorite.java
+++ b/src/main/java/com/floney/floney/book/domain/favorite/Favorite.java
@@ -1,0 +1,42 @@
+package com.floney.floney.book.domain.favorite;
+
+import com.floney.floney.book.domain.category.entity.Category;
+import com.floney.floney.book.domain.category.entity.Subcategory;
+import com.floney.floney.book.domain.entity.Book;
+import com.floney.floney.common.entity.BaseEntity;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Getter
+@Builder
+@DynamicInsert
+@DynamicUpdate
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Book book;
+
+    @Column(nullable = false)
+    private Double money;
+
+    @Column
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category lineCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Subcategory lineSubcategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Subcategory assetSubcategory;
+}

--- a/src/main/java/com/floney/floney/book/dto/request/FavoriteCreateRequest.java
+++ b/src/main/java/com/floney/floney/book/dto/request/FavoriteCreateRequest.java
@@ -1,0 +1,12 @@
+package com.floney.floney.book.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public record FavoriteCreateRequest(
+    @NotNull(message = "money를 입력해주세요") Double money,
+    String description,
+    @NotBlank(message = "lineCategoryName를 입력해주세요") String lineCategoryName,
+    @NotBlank(message = "lineSubcategoryName를 입력해주세요") String lineSubcategoryName,
+    @NotBlank(message = "assetSubcategoryName를 입력해주세요") String assetSubcategoryName) {
+}

--- a/src/main/java/com/floney/floney/book/dto/response/FavoriteResponse.java
+++ b/src/main/java/com/floney/floney/book/dto/response/FavoriteResponse.java
@@ -1,9 +1,22 @@
 package com.floney.floney.book.dto.response;
 
+import com.floney.floney.book.domain.favorite.Favorite;
+
 public record FavoriteResponse(long id,
                                double money,
                                String description,
                                String lineCategoryName,
                                String lineSubcategoryName,
                                String assetSubcategoryName) {
+
+    public static FavoriteResponse from(final Favorite favorite) {
+        return new FavoriteResponse(
+            favorite.getId(),
+            favorite.getMoney(),
+            favorite.getDescription(),
+            favorite.getLineCategory().getName().getMeaning(),
+            favorite.getLineSubcategory().getName(),
+            favorite.getAssetSubcategory().getName()
+        );
+    }
 }

--- a/src/main/java/com/floney/floney/book/dto/response/FavoriteResponse.java
+++ b/src/main/java/com/floney/floney/book/dto/response/FavoriteResponse.java
@@ -1,0 +1,9 @@
+package com.floney.floney.book.dto.response;
+
+public record FavoriteResponse(long id,
+                               double money,
+                               String description,
+                               String lineCategoryName,
+                               String lineSubcategoryName,
+                               String assetSubcategoryName) {
+}

--- a/src/main/java/com/floney/floney/book/repository/favorite/FavoriteRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/favorite/FavoriteRepository.java
@@ -1,0 +1,7 @@
+package com.floney.floney.book.repository.favorite;
+
+import com.floney.floney.book.domain.favorite.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+}

--- a/src/main/java/com/floney/floney/book/repository/favorite/FavoriteRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/favorite/FavoriteRepository.java
@@ -1,7 +1,16 @@
 package com.floney.floney.book.repository.favorite;
 
+import com.floney.floney.book.domain.entity.Book;
 import com.floney.floney.book.domain.favorite.Favorite;
+import com.floney.floney.common.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import javax.persistence.LockModeType;
+import java.util.List;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Favorite> findAllExclusivelyByBookAndStatus(final Book book, final Status status);
 }

--- a/src/main/java/com/floney/floney/book/service/FavoriteService.java
+++ b/src/main/java/com/floney/floney/book/service/FavoriteService.java
@@ -1,0 +1,9 @@
+package com.floney.floney.book.service;
+
+import com.floney.floney.book.dto.request.FavoriteCreateRequest;
+import com.floney.floney.book.dto.response.FavoriteResponse;
+
+public interface FavoriteService {
+
+    FavoriteResponse createFavorite(String bookKey, String userEmail, FavoriteCreateRequest request);
+}

--- a/src/main/java/com/floney/floney/book/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/FavoriteServiceImpl.java
@@ -1,0 +1,83 @@
+package com.floney.floney.book.service;
+
+import com.floney.floney.book.domain.category.CategoryType;
+import com.floney.floney.book.domain.category.entity.Category;
+import com.floney.floney.book.domain.category.entity.Subcategory;
+import com.floney.floney.book.domain.entity.Book;
+import com.floney.floney.book.domain.favorite.Favorite;
+import com.floney.floney.book.dto.request.FavoriteCreateRequest;
+import com.floney.floney.book.dto.response.FavoriteResponse;
+import com.floney.floney.book.repository.BookRepository;
+import com.floney.floney.book.repository.BookUserRepository;
+import com.floney.floney.book.repository.category.CategoryRepository;
+import com.floney.floney.book.repository.favorite.FavoriteRepository;
+import com.floney.floney.common.exception.book.NotFoundBookException;
+import com.floney.floney.common.exception.book.NotFoundBookUserException;
+import com.floney.floney.common.exception.book.NotFoundCategoryException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.floney.floney.book.domain.category.CategoryType.ASSET;
+import static com.floney.floney.common.constant.Status.ACTIVE;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class FavoriteServiceImpl implements FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final BookRepository bookRepository;
+    private final BookUserRepository bookUserRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public FavoriteResponse createFavorite(final String bookKey,
+                                           final String userEmail,
+                                           final FavoriteCreateRequest request) {
+        if (!bookUserRepository.existsByBookKeyAndUserEmail(bookKey, userEmail)) {
+            log.warn("사용자가 자신이 참여하지 않은 가계부로 요청 - bookKey: {}, 사용자: {}", bookKey, userEmail);
+            throw new NotFoundBookUserException(bookKey, userEmail);
+        }
+
+        final Book book = findBook(bookKey);
+        final Category lineCategory = findLineCategory(request.lineCategoryName());
+        final Subcategory lineSubcategory = findLineSubcategory(request.lineSubcategoryName(), lineCategory, book);
+        final Subcategory assetSubcategory = findAssetSubcategory(book, request.assetSubcategoryName());
+
+        final Favorite favorite = Favorite.builder()
+            .book(book)
+            .money(request.money())
+            .description(request.description())
+            .lineCategory(lineCategory)
+            .lineSubcategory(lineSubcategory)
+            .assetSubcategory(assetSubcategory)
+            .build();
+        favoriteRepository.save(favorite);
+
+        return FavoriteResponse.from(favorite);
+    }
+
+    private Book findBook(final String bookKey) {
+        return bookRepository.findBookByBookKeyAndStatus(bookKey, ACTIVE)
+            .orElseThrow(() -> new NotFoundBookException(bookKey));
+    }
+
+    private Category findLineCategory(final String categoryName) {
+        final CategoryType categoryType = CategoryType.findLineByMeaning(categoryName);
+        return categoryRepository.findByType(categoryType)
+            .orElseThrow(() -> new NotFoundCategoryException(categoryName));
+    }
+
+    private Subcategory findLineSubcategory(final String lineSubCategoryName, final Category lineCategory, final Book book) {
+        return categoryRepository.findSubcategory(lineSubCategoryName, book, lineCategory.getName())
+            .orElseThrow(() -> new NotFoundCategoryException(lineSubCategoryName));
+    }
+
+    private Subcategory findAssetSubcategory(final Book book, final String assetSubCategoryName) {
+        return categoryRepository.findSubcategory(assetSubCategoryName, book, ASSET)
+            .orElseThrow(() -> new NotFoundCategoryException(assetSubCategoryName));
+    }
+}

--- a/src/main/java/com/floney/floney/book/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/FavoriteServiceImpl.java
@@ -38,10 +38,7 @@ public class FavoriteServiceImpl implements FavoriteService {
     public FavoriteResponse createFavorite(final String bookKey,
                                            final String userEmail,
                                            final FavoriteCreateRequest request) {
-        if (!bookUserRepository.existsByBookKeyAndUserEmail(bookKey, userEmail)) {
-            log.warn("사용자가 자신이 참여하지 않은 가계부로 요청 - bookKey: {}, 사용자: {}", bookKey, userEmail);
-            throw new NotFoundBookUserException(bookKey, userEmail);
-        }
+        validateBookUser(bookKey, userEmail);
 
         final Book book = findBook(bookKey);
         validateFavoriteSizeByBook(book);
@@ -61,6 +58,12 @@ public class FavoriteServiceImpl implements FavoriteService {
         favoriteRepository.save(favorite);
 
         return FavoriteResponse.from(favorite);
+    }
+
+    private void validateBookUser(final String bookKey, final String userEmail) {
+        if (!bookUserRepository.existsByBookKeyAndUserEmail(bookKey, userEmail)) {
+            throw new NotFoundBookUserException(bookKey, userEmail);
+        }
     }
 
     private void validateFavoriteSizeByBook(final Book book) {

--- a/src/main/java/com/floney/floney/common/exception/book/FavoriteSizeInvalidException.java
+++ b/src/main/java/com/floney/floney/common/exception/book/FavoriteSizeInvalidException.java
@@ -1,0 +1,17 @@
+package com.floney.floney.common.exception.book;
+
+import com.floney.floney.common.exception.common.ErrorType;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public class FavoriteSizeInvalidException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    public FavoriteSizeInvalidException(final String bookKey) {
+        log.warn("즐겨찾기 개수 초과 - 가계부: {}", bookKey);
+        this.errorType = ErrorType.INVALID_FAVORITE_SIZE;
+    }
+}

--- a/src/main/java/com/floney/floney/common/exception/book/NotFoundBookUserException.java
+++ b/src/main/java/com/floney/floney/common/exception/book/NotFoundBookUserException.java
@@ -2,16 +2,16 @@ package com.floney.floney.common.exception.book;
 
 import com.floney.floney.common.exception.common.ErrorType;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 public class NotFoundBookUserException extends RuntimeException {
-    private final ErrorType errorType;
-    private final String bookKey;
-    private final String requestUser;
 
-    public NotFoundBookUserException(String bookKey, String requestUser) {
-        errorType = ErrorType.NOT_FOUND_BOOK_USER;
-        this.bookKey = bookKey;
-        this.requestUser = requestUser;
+    private final ErrorType errorType;
+
+    public NotFoundBookUserException(final String bookKey, final String userEmail) {
+        log.warn("사용자가 자신이 참여하지 않은 가계부로 요청 - 가계부: {}, 사용자: {}", bookKey, userEmail);
+        this.errorType = ErrorType.NOT_FOUND_BOOK_USER;
     }
 }

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
@@ -257,6 +257,12 @@ public class ErrorControllerAdvice {
             .body(ErrorResponse.of(exception.getErrorType()));
     }
 
+    @ExceptionHandler(FavoriteSizeInvalidException.class)
+    protected ResponseEntity<ErrorResponse> favoriteSizeInvalidException(FavoriteSizeInvalidException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.of(exception.getErrorType()));
+    }
+
     // SETTLEMENT
     @ExceptionHandler(SettlementNotFoundException.class)
     protected ResponseEntity<ErrorResponse> settlementNotFoundException(SettlementNotFoundException exception) {

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorControllerAdvice.java
@@ -175,11 +175,6 @@ public class ErrorControllerAdvice {
 
     @ExceptionHandler(NotFoundBookUserException.class)
     protected ResponseEntity<ErrorResponse> notFoundUser(NotFoundBookUserException exception) {
-        logger.warn("가계부 키 [{}] 에서 [{}]와 일치하는 {}",
-            exception.getBookKey(),
-            exception.getRequestUser(),
-            ErrorType.NOT_FOUND_BOOK_USER.getMessage());
-
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse.of(exception.getErrorType()));
     }

--- a/src/main/java/com/floney/floney/common/exception/common/ErrorType.java
+++ b/src/main/java/com/floney/floney/common/exception/common/ErrorType.java
@@ -45,6 +45,7 @@ public enum ErrorType {
     ALREADY_EXIST("B011", "이미 존재하는 데이터입니다"),
     CANNOT_ANALYZE("B012", "분석이 불가능한 카테고리입니다"),
     NOT_FOUND_REPEAT_LINE("B013", "존재하지 않는 반복 내역입니다"),
+    INVALID_FAVORITE_SIZE("B014", "즐겨찾기 개수가 초과되었습니다"),
 
     LIMIT("S002", "제공하지 않는 서비스입니다"),
 

--- a/src/main/resources/db/migration/mysql/V16__add_favorite.sql
+++ b/src/main/resources/db/migration/mysql/V16__add_favorite.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS `favorite`
+(
+    `id`                   bigint       NOT NULL AUTO_INCREMENT,
+    `created_at`           datetime(6)  NOT NULL DEFAULT current_timestamp(6),
+    `status`               varchar(255) NOT NULL DEFAULT 'ACTIVE',
+    `updated_at`           datetime(6)  NOT NULL DEFAULT current_timestamp(6),
+    `book_id`              bigint       NOT NULL,
+    `money`                double       NOT NULL,
+    `description`          varchar(255),
+    `line_category_id`     bigint       NOT NULL,
+    `line_subcategory_id`  bigint       NOT NULL,
+    `asset_subcategory_id` bigint       NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `fk_book_in_favorite` (`book_id`),
+    KEY `fk_line_category_in_favorite` (`line_category_id`),
+    KEY `fk_line_subcategory_in_favorite` (`line_subcategory_id`),
+    KEY `fk_asset_subcategory_in_favorite` (`asset_subcategory_id`)
+);

--- a/src/test/java/com/floney/floney/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/com/floney/floney/acceptance/FavoriteAcceptanceTest.java
@@ -144,7 +144,7 @@ public class FavoriteAcceptanceTest {
                     .statusCode(HttpStatus.BAD_REQUEST.value())
                     .body(
                         "code", is("1"),
-                        "message", is("lineSubcategoryName를 입력해주세요")
+                        "message", containsString("입력해주세요")
                     );
             }
         }

--- a/src/test/java/com/floney/floney/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/com/floney/floney/acceptance/FavoriteAcceptanceTest.java
@@ -111,5 +111,42 @@ public class FavoriteAcceptanceTest {
                     );
             }
         }
+
+        @Nested
+        @DisplayName("특정 값 없이 요청한 경우")
+        class Context_With_InvalidRequest {
+
+            String accessToken;
+            String bookKey;
+
+            @BeforeEach
+            void init() {
+                accessToken = UserApiFixture.loginAfterSignup(UserFixture.emailUser()).getAccessToken();
+                bookKey = BookApiFixture.createBook(accessToken).getBookKey();
+            }
+
+            @Test
+            @DisplayName("에러가 발생한다.")
+            void it_returns_error() {
+                RestAssured.given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .auth().oauth2(accessToken)
+                    .body("""
+                        {
+                            "lineCategoryName": "",
+                            "lineSubcategoryName": "",
+                            "assetSubcategoryName": ""
+                        }
+                        """)
+                    .when()
+                    .post("/books/{key}/favorites", bookKey)
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body(
+                        "code", is("1"),
+                        "message", is("lineSubcategoryName를 입력해주세요")
+                    );
+            }
+        }
     }
 }

--- a/src/test/java/com/floney/floney/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/com/floney/floney/acceptance/FavoriteAcceptanceTest.java
@@ -1,0 +1,72 @@
+package com.floney.floney.acceptance;
+
+import com.floney.floney.acceptance.config.AcceptanceTest;
+import com.floney.floney.acceptance.fixture.BookApiFixture;
+import com.floney.floney.acceptance.fixture.UserApiFixture;
+import com.floney.floney.fixture.UserFixture;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.*;
+
+@AcceptanceTest
+@DisplayName("인수 테스트: 즐겨찾기")
+public class FavoriteAcceptanceTest {
+
+    @Nested
+    @DisplayName("즐겨찾기를 추가할 때")
+    class Context_createFavorite {
+
+        @Nested
+        @DisplayName("description 을 제외한 모든 값이 주어진 경우")
+        class Describe_requestWithoutDescription {
+
+            String accessToken;
+            String bookKey;
+
+            final double money = 10000;
+            final String lineCategoryName = "지출";
+            final String lineSubcategoryName = "식비";
+            final String assetSubcategoryName = "현금";
+
+            @BeforeEach
+            void init() {
+                accessToken = UserApiFixture.loginAfterSignup(UserFixture.emailUser()).getAccessToken();
+                bookKey = BookApiFixture.createBook(accessToken).getBookKey();
+            }
+
+            @Test
+            @DisplayName("즐겨찾기가 생성된다.")
+            void it_returns_favorite() {
+                RestAssured.given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .auth().oauth2(accessToken)
+                    .body("""
+                        {
+                            "money": %s,
+                            "lineCategoryName": "%s",
+                            "lineSubcategoryName": "%s",
+                            "assetSubcategoryName": "%s"
+                        }
+                        """.formatted(money, lineCategoryName, lineSubcategoryName, assetSubcategoryName))
+                    .when()
+                    .post("/books/{key}/favorites", bookKey)
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .body(
+                        "id", notNullValue(),
+                        "money", is((float) money),
+                        "description", nullValue(),
+                        "lineCategoryName", is(lineCategoryName),
+                        "lineSubcategoryName", is(lineSubcategoryName),
+                        "assetSubcategoryName", is(assetSubcategoryName)
+                    );
+            }
+        }
+    }
+}

--- a/src/test/java/com/floney/floney/acceptance/fixture/FavoriteApiFixture.java
+++ b/src/test/java/com/floney/floney/acceptance/fixture/FavoriteApiFixture.java
@@ -1,0 +1,33 @@
+package com.floney.floney.acceptance.fixture;
+
+import io.restassured.RestAssured;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.notNullValue;
+
+public final class FavoriteApiFixture {
+
+    private FavoriteApiFixture() {
+    }
+
+    public static int createFavorite(final String accessToken, final String bookKey) {
+        return RestAssured.given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .auth().oauth2(accessToken)
+            .body("""
+                {
+                    "money": 1000,
+                    "lineCategoryName": "지출",
+                    "lineSubcategoryName": "식비",
+                    "assetSubcategoryName": "현금"
+                }
+                """)
+            .when()
+            .post("/books/{key}/favorites", bookKey)
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .body("id", notNullValue())
+            .extract().path("id");
+    }
+}

--- a/src/test/resources/clear.sql
+++ b/src/test/resources/clear.sql
@@ -4,6 +4,7 @@ truncate table `book_line`;
 truncate table `book_line_category`;
 truncate table `book_user`;
 truncate table `budget`;
+truncate table `favorite`;
 truncate table `subcategory`;
 truncate table `settlement`;
 truncate table `settlement_user`;


### PR DESCRIPTION
## 📌 개요

즐겨찾기 추가 API 구현

## ✅ 개발 내용

- 가계부 당 즐겨찾기 개수 10개 제한 구현
- 가계부원이 아닌 사용자가 즐겨찾기 추가 요청 시 제한 구현
- 관련 인수 테스트 추가
