### PR TITLE
#468 feat: 즐겨찾기 개수 제한을 카테고리 당 5개로 수정

### DIFF
--- a/src/main/java/com/floney/floney/book/domain/category/entity/Category.java
+++ b/src/main/java/com/floney/floney/book/domain/category/entity/Category.java
@@ -23,6 +23,8 @@ import static com.floney.floney.book.domain.category.CategoryType.OUTCOME;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Category extends BaseEntity {
 
+    public static final int FAVORITE_MAX_SIZE = 5;
+
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private CategoryType name;

--- a/src/main/java/com/floney/floney/book/domain/entity/Book.java
+++ b/src/main/java/com/floney/floney/book/domain/entity/Book.java
@@ -26,7 +26,6 @@ import java.time.LocalDate;
 public class Book extends BaseEntity {
 
     private static final double DEFAULT = 0.0;
-    public static final int FAVORITE_MAX_SIZE = 10;
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/com/floney/floney/book/repository/favorite/FavoriteRepository.java
+++ b/src/main/java/com/floney/floney/book/repository/favorite/FavoriteRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    List<Favorite> findAllExclusivelyByBookAndStatus(final Book book, final Status status);
+    List<Favorite> findAllExclusivelyByBookAndLineCategoryAndStatus(final Book book, final Category lineCategory, final Status status);
 
     List<Favorite> findAllByBookAndLineCategoryAndStatusOrderByIdDesc(final Book book, final Category lineCategory, final Status status);
 }

--- a/src/main/java/com/floney/floney/book/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/FavoriteServiceImpl.java
@@ -40,9 +40,9 @@ public class FavoriteServiceImpl implements FavoriteService {
         validateBookUser(bookKey, userEmail);
 
         final Book book = findBook(bookKey);
-        validateFavoriteSizeByBook(book);
-
         final Category lineCategory = findLineCategory(request.lineCategoryName());
+        validateFavoriteSize(book, lineCategory);
+
         final Subcategory lineSubcategory = findLineSubcategory(request.lineSubcategoryName(), lineCategory, book);
         final Subcategory assetSubcategory = findAssetSubcategory(book, request.assetSubcategoryName());
 
@@ -114,13 +114,13 @@ public class FavoriteServiceImpl implements FavoriteService {
         }
     }
 
-    private void validateFavoriteSizeByBook(final Book book) {
-        final int favoriteSize = favoriteRepository.findAllExclusivelyByBookAndStatus(book, ACTIVE).size();
-        if (favoriteSize == Book.FAVORITE_MAX_SIZE) {
-            throw new FavoriteSizeInvalidException(book.getBookKey());
-        } else if (favoriteSize > Book.FAVORITE_MAX_SIZE) {
-            log.error("가계부의 즐겨찾기 개수가 이미 {}개를 초과 - 가계부: {}", Book.FAVORITE_MAX_SIZE, book.getBookKey());
-            throw new FavoriteSizeInvalidException(book.getBookKey());
+    private void validateFavoriteSize(final Book book, final Category category) {
+        final int favoriteSize = favoriteRepository.findAllExclusivelyByBookAndLineCategoryAndStatus(book, category, ACTIVE).size();
+        if (favoriteSize == Category.FAVORITE_MAX_SIZE) {
+            throw new FavoriteSizeInvalidException(book.getBookKey(), category.getName());
+        } else if (favoriteSize > Category.FAVORITE_MAX_SIZE) {
+            log.error("가계부({})의 {} 카테고리의 즐겨찾기 개수가 이미 {}개를 초과", book.getBookKey(), category.getName(), Category.FAVORITE_MAX_SIZE);
+            throw new FavoriteSizeInvalidException(book.getBookKey(), category.getName());
         }
     }
 

--- a/src/main/java/com/floney/floney/common/exception/book/FavoriteSizeInvalidException.java
+++ b/src/main/java/com/floney/floney/common/exception/book/FavoriteSizeInvalidException.java
@@ -1,5 +1,6 @@
 package com.floney.floney.common.exception.book;
 
+import com.floney.floney.book.domain.category.CategoryType;
 import com.floney.floney.common.exception.common.ErrorType;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -10,8 +11,8 @@ public class FavoriteSizeInvalidException extends RuntimeException {
 
     private final ErrorType errorType;
 
-    public FavoriteSizeInvalidException(final String bookKey) {
-        log.warn("즐겨찾기 개수 초과 - 가계부: {}", bookKey);
+    public FavoriteSizeInvalidException(final String bookKey, final CategoryType categoryType) {
+        log.warn("즐겨찾기 개수 초과 - 가계부: {}, 카테고리: {}", bookKey, categoryType);
         this.errorType = ErrorType.INVALID_FAVORITE_SIZE;
     }
 }

--- a/src/test/java/com/floney/floney/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/com/floney/floney/acceptance/FavoriteAcceptanceTest.java
@@ -77,8 +77,8 @@ public class FavoriteAcceptanceTest {
         }
 
         @Nested
-        @DisplayName("이미 해당 가계부에 10개의 즐겨찾기가 존재하는 경우")
-        class Context_With_10Favorites {
+        @DisplayName("이미 해당 가계부 및 카테고리에 5개의 즐겨찾기가 존재하는 경우")
+        class Context_With_AllFavorites {
 
             String accessToken;
             String bookKey;
@@ -87,8 +87,8 @@ public class FavoriteAcceptanceTest {
             void init() {
                 accessToken = UserApiFixture.loginAfterSignup(UserFixture.emailUser()).getAccessToken();
                 bookKey = BookApiFixture.createBook(accessToken).getBookKey();
-                for (int i = 0; i < 10; i++) {
-                    FavoriteApiFixture.createFavorite(accessToken, bookKey);
+                for (int i = 0; i < 5; i++) {
+                    FavoriteApiFixture.createFavoriteByLineCategory(accessToken, bookKey, "지출", "식비");
                 }
             }
 


### PR DESCRIPTION
## 📌 개요

즐겨찾기 개수 제한을 카테고리 당 5개로 수정했다.

## ✅ 개발 내용

- 카테고리 추가 시 유효성 검증 수정
- 관련 테스트 수정
