### PR TITLE
#470 feat: 임시 비밀번호 길이 수정

### DIFF
--- a/src/main/java/com/floney/floney/user/entity/User.java
+++ b/src/main/java/com/floney/floney/user/entity/User.java
@@ -33,7 +33,7 @@ public class User extends BaseEntity {
     public static final String DELETE_VALUE = "알수없음";
 
     private static final int EMAIL_MAX_LENGTH = 350;
-    private static final int PASSWORD_MIN_LENGTH = 8;
+    public static final int PASSWORD_MIN_LENGTH = 8;
     public static final int PASSWORD_MAX_LENGTH = 32;
     private static final int NICKNAME_MAX_LENGTH = 8;
 

--- a/src/main/java/com/floney/floney/user/service/UserService.java
+++ b/src/main/java/com/floney/floney/user/service/UserService.java
@@ -184,7 +184,7 @@ public class UserService {
     }
 
     private String generatePassword(final String email) {
-        final String newPassword = RandomStringUtils.random(User.PASSWORD_MAX_LENGTH, true, true);
+        final String newPassword = RandomStringUtils.random(User.PASSWORD_MIN_LENGTH, true, true);
         final RegeneratePasswordMail mail = RegeneratePasswordMail.create(email, newPassword);
         mailProvider.sendMail(mail);
         return newPassword;


### PR DESCRIPTION
## 📌 개요

임시 비밀번호 길이를 8자로 수정했다.

## ✅ 개발 내용

- 임시 비밀번호 길이를 8자로 수정
