### PR TITLE
fix: 반복 내역 주말 날짜 선택 후 평일에만 날짜 조정되도록 수정 

### DIFF
--- a/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookLineServiceImpl.java
@@ -154,7 +154,7 @@ public class BookLineServiceImpl implements BookLineService {
         LocalDate date = bookLine.getLineDate();
 
         // 가계부 내역 날짜로 주말을 골랐지만, 반복 주기가 평일인 경우
-        if (DateUtil.isWeekend(date) && !repeatDuration.equals(RepeatDuration.WEEKEND)) {
+        if (DateUtil.isWeekend(date) && repeatDuration.equals(RepeatDuration.WEEKDAY)) {
             LocalDate nextSaturday = date.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
             bookLine.updateDate(nextSaturday);
         }
@@ -169,7 +169,7 @@ public class BookLineServiceImpl implements BookLineService {
     private BookLineResponse createBookLineByRepeat(final BookLine bookLine, final RepeatDuration requestRepeatDuration) {
         // 1. 날짜와 반복 주기 정합성 체크
         checkDateByRepeatDuration(requestRepeatDuration, bookLine);
-        
+
         // 2. 반복 내역 객체 생성
         RepeatBookLine repeatBookLine = RepeatBookLine.of(bookLine, requestRepeatDuration);
 

--- a/src/test/java/com/floney/floney/acceptance/BookAcceptanceTest.java
+++ b/src/test/java/com/floney/floney/acceptance/BookAcceptanceTest.java
@@ -280,6 +280,45 @@ public class BookAcceptanceTest {
                     .hasFieldOrPropertyWithValue("lineDate", LocalDate.of(2024, 4, 15));
             }
         }
+
+        @Nested
+        @DisplayName("반복 주기는 매주고 내역 날짜는 주말을 생성한 경우")
+        class Context_With_RepeatBookLine_EveryWeek {
+
+            final User user = UserFixture.emailUser();
+            String accessToken = UserApiFixture.loginAfterSignup(user).getAccessToken();
+            String bookKey = BookApiFixture.createBook(accessToken).getBookKey();
+
+            private BookLineRequest request;
+
+            @BeforeEach
+            public void init() {
+
+                String incomeLineCategory = "수입";
+                String subCategory = "급여";
+                String assetSubCategory = "체크카드";
+                LocalDate weekendDate = LocalDate.of(2024, 5, 26);
+                request = BookRequestDtoFixture.createBookLineRequest(weekendDate, bookKey, incomeLineCategory, subCategory,
+                    assetSubCategory, WEEK);
+            }
+
+            @Test
+            @DisplayName("선텍한 날짜로 반복내역이 생성된다")
+            void it_succeeds() {
+                final BookLineResponse response = RestAssured
+                    .given()
+                    .auth().oauth2(accessToken)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when().post("/books/lines")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .extract().as(BookLineResponse.class);
+
+                assertThat(response)
+                    .hasFieldOrPropertyWithValue("lineDate", LocalDate.of(2024, 5, 26));
+            }
+        }
     }
 
 


### PR DESCRIPTION
## 📌 개요

반복 내역 -> 주말 날짜 선택 후 
매주 매달 선택 시 일자 미 조정 되도록 수정

## ✅ 개발 내용

- 평일로 반복 주기 선택시에만 조정되도록 수정
