### PR TITLE
#487 fix: 정산 세부 내역 조회 시, 비활성화 유저 처리

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*.java @sienna011022 @dahyen0o @sejeongsong
+*.java @Floney-2023/server

--- a/src/main/java/com/floney/floney/book/service/BookServiceImpl.java
+++ b/src/main/java/com/floney/floney/book/service/BookServiceImpl.java
@@ -23,6 +23,7 @@ import com.floney.floney.book.repository.favorite.FavoriteRepository;
 import com.floney.floney.common.domain.vo.DateDuration;
 import com.floney.floney.common.exception.book.*;
 import com.floney.floney.settlement.repository.SettlementRepository;
+import com.floney.floney.settlement.repository.SettlementUserRepository;
 import com.floney.floney.user.dto.security.CustomUserDetails;
 import com.floney.floney.user.entity.User;
 import com.floney.floney.user.repository.UserRepository;
@@ -59,6 +60,7 @@ public class BookServiceImpl implements BookService {
     private final AlarmRepository alarmRepository;
     private final RepeatBookLineRepository repeatBookLineRepository;
     private final FavoriteRepository favoriteRepository;
+    private final SettlementUserRepository settlementUserRepository;
 
     @Override
     @Transactional
@@ -380,6 +382,7 @@ public class BookServiceImpl implements BookService {
         });
         bookLineCategoryRepository.inactiveAllByBookUser(bookUser);
         repeatBookLineRepository.inactiveAllByBookUser(bookUser);
+        settlementUserRepository.inactiveAllByBookAndUser(bookUser.getBook(), bookUser.getUser());
     }
 
     private void saveDefaultCategories(final Book book) {

--- a/src/main/java/com/floney/floney/settlement/dto/response/SettlementResponse.java
+++ b/src/main/java/com/floney/floney/settlement/dto/response/SettlementResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.floney.floney.settlement.domain.entity.Settlement;
 import com.floney.floney.settlement.domain.entity.SettlementUser;
+import com.floney.floney.user.entity.User;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,25 +29,25 @@ public class SettlementResponse {
 
     public static SettlementResponse from(Settlement settlement) {
         return SettlementResponse.builder()
-                .id(settlement.getId())
-                .startDate(settlement.getStartDate())
-                .endDate(settlement.getEndDate())
-                .userCount(settlement.getUserCount())
-                .totalOutcome(settlement.getTotalOutcome())
-                .outcome(settlement.getAvgOutcome())
-                .build();
+            .id(settlement.getId())
+            .startDate(settlement.getStartDate())
+            .endDate(settlement.getEndDate())
+            .userCount(settlement.getUserCount())
+            .totalOutcome(settlement.getTotalOutcome())
+            .outcome(settlement.getAvgOutcome())
+            .build();
     }
 
     public static SettlementResponse of(Settlement settlement, List<SettlementUser> settlementUsers) {
         return SettlementResponse.builder()
-                .id(settlement.getId())
-                .startDate(settlement.getStartDate())
-                .endDate(settlement.getEndDate())
-                .userCount(settlement.getUserCount())
-                .totalOutcome(settlement.getTotalOutcome())
-                .outcome(settlement.getAvgOutcome())
-                .details(settlementUsers.stream().map(DetailResponse::from).toList())
-                .build();
+            .id(settlement.getId())
+            .startDate(settlement.getStartDate())
+            .endDate(settlement.getEndDate())
+            .userCount(settlement.getUserCount())
+            .totalOutcome(settlement.getTotalOutcome())
+            .outcome(settlement.getAvgOutcome())
+            .details(settlementUsers.stream().map(DetailResponse::from).toList())
+            .build();
     }
 
     @Getter
@@ -58,12 +59,19 @@ public class SettlementResponse {
         private String userProfileImg;
         private Double money;
 
-        private static DetailResponse from(SettlementUser settlementUser) {
-            return DetailResponse.builder()
-                    .userNickname(settlementUser.getUser().getNickname())
-                    .userProfileImg(settlementUser.getUser().getProfileImg())
+        private static DetailResponse from(final SettlementUser settlementUser) {
+            if (settlementUser.getUser() == null) {
+                return DetailResponse.builder()
+                    .userNickname(User.DELETE_VALUE)
+                    .userProfileImg(null)
                     .money(settlementUser.getMoney())
                     .build();
+            }
+            return DetailResponse.builder()
+                .userNickname(settlementUser.getUser().getNickname())
+                .userProfileImg(settlementUser.getUser().getProfileImg())
+                .money(settlementUser.getMoney())
+                .build();
         }
     }
 }

--- a/src/main/java/com/floney/floney/settlement/repository/SettlementUserCustomRepository.java
+++ b/src/main/java/com/floney/floney/settlement/repository/SettlementUserCustomRepository.java
@@ -1,6 +1,11 @@
 package com.floney.floney.settlement.repository;
 
+import com.floney.floney.book.domain.entity.Book;
+import com.floney.floney.user.entity.User;
+
 public interface SettlementUserCustomRepository {
 
     void inactiveAllByBookId(long bookId);
+
+    void inactiveAllByBookAndUser(final Book book, User user);
 }

--- a/src/main/java/com/floney/floney/settlement/repository/SettlementUserCustomRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/settlement/repository/SettlementUserCustomRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.floney.floney.settlement.repository;
 
+import com.floney.floney.book.domain.entity.Book;
+import com.floney.floney.user.entity.User;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -36,6 +38,26 @@ public class SettlementUserCustomRepositoryImpl implements SettlementUserCustomR
             .set(settlementUser.updatedAt, LocalDateTime.now())
             .where(
                 settlementUser.settlement.id.in(settlementByBookId),
+                settlementUser.status.eq(ACTIVE)
+            )
+            .execute();
+
+        entityManager.clear();
+    }
+
+    @Override
+    @Transactional
+    public void inactiveAllByBookAndUser(final Book book, final User user) {
+        final JPQLQuery<Long> settlementByBook = JPAExpressions.select(settlement.id)
+            .from(settlement)
+            .where(settlement.book.eq(book));
+
+        jpaQueryFactory.update(settlementUser)
+            .set(settlementUser.status, INACTIVE)
+            .set(settlementUser.updatedAt, LocalDateTime.now())
+            .where(
+                settlementUser.user.eq(user),
+                settlementUser.settlement.id.in(settlementByBook),
                 settlementUser.status.eq(ACTIVE)
             )
             .execute();

--- a/src/main/java/com/floney/floney/settlement/repository/SettlementUserRepository.java
+++ b/src/main/java/com/floney/floney/settlement/repository/SettlementUserRepository.java
@@ -1,6 +1,5 @@
 package com.floney.floney.settlement.repository;
 
-import com.floney.floney.common.constant.Status;
 import com.floney.floney.settlement.domain.entity.Settlement;
 import com.floney.floney.settlement.domain.entity.SettlementUser;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +10,5 @@ import java.util.List;
 @Repository
 public interface SettlementUserRepository extends JpaRepository<SettlementUser, Long>, SettlementUserCustomRepository {
 
-    List<SettlementUser> findAllBySettlementAndStatus(Settlement settlement, Status status);
+    List<SettlementUser> findAllBySettlement(Settlement settlement);
 }

--- a/src/main/java/com/floney/floney/settlement/service/SettlementService.java
+++ b/src/main/java/com/floney/floney/settlement/service/SettlementService.java
@@ -41,9 +41,9 @@ public class SettlementService {
         final Book book = findBookByBookKey(bookKey);
 
         return findSettlementsOrderByRecentTime(book)
-                .stream()
-                .map(SettlementResponse::from)
-                .toList();
+            .stream()
+            .map(SettlementResponse::from)
+            .toList();
     }
 
     public SettlementResponse find(final String email, final Long id) {
@@ -79,7 +79,7 @@ public class SettlementService {
 
     private Settlement findSettlementById(final Long id) {
         return settlementRepository.findById(id)
-                .orElseThrow(() -> new SettlementNotFoundException(id));
+            .orElseThrow(() -> new SettlementNotFoundException(id));
     }
 
     private List<Settlement> findSettlementsOrderByRecentTime(final Book book) {
@@ -87,12 +87,13 @@ public class SettlementService {
     }
 
     private List<SettlementUser> findSettlementUsersBySettlement(final Settlement settlement) {
-        return settlementUserRepository.findAllBySettlementAndStatus(settlement, Status.ACTIVE);
+        // 정산은 탈퇴 혹은 가계부를 나간 사용자도 조회한다.
+        return settlementUserRepository.findAllBySettlement(settlement);
     }
 
     private Book findBookByBookKey(final String bookKey) {
         return bookRepository.findBookByBookKeyAndStatus(bookKey, Status.ACTIVE)
-                .orElseThrow(() -> new NotFoundBookException(bookKey));
+            .orElseThrow(() -> new NotFoundBookException(bookKey));
     }
 
     private void validateBookUsers(final String bookKey, final Set<String> emails) {
@@ -129,6 +130,6 @@ public class SettlementService {
 
     private User findUserByEmail(final String email) {
         return userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserNotFoundException(email));
+            .orElseThrow(() -> new UserNotFoundException(email));
     }
 }


### PR DESCRIPTION
## 📌 개요

정산 세부 내역 조회 시, 비활성화(탈퇴 혹은 가계부 나가기) 유저에 대해 알맞은 응답값을 내려주도록 수정한다.

## ✅ 개발 내용

- 가계부 나가기 API 에서 빠진 SettlementUser 삭제 로직 추가
- 정산 세부 조회 API 에서 응답값 '알수없음' 처리

## 참고

1. DB 데이터 삭제 이벤트에서 SettlementUser 삭제는 제외합니다. (논리 삭제된 데이터까지 조회가 필요하기 때문)
