### PR TITLE
hotfix : 마이페이지 유저 조회 시, active인 bookUser만 집계

### DIFF
--- a/src/main/java/com/floney/floney/book/repository/BookUserRepositoryImpl.java
+++ b/src/main/java/com/floney/floney/book/repository/BookUserRepositoryImpl.java
@@ -159,6 +159,7 @@ public class BookUserRepositoryImpl implements BookUserCustomRepository {
                 ))
             .from(bookUser)
             .where(
+                bookUser.status.eq(ACTIVE),
                 bookUser.book.id.in(booksByUser)
             )
             .groupBy(bookUser.book)


### PR DESCRIPTION
## 📌 개요

한 줄 개요

## ✅ 개발 내용

- 마이페이지 조회 시 inactive인 유저까지 집계되는 현상