### PR TITLE
#503 fix: 가계부 나간 유저도 알수없음 처리

### DIFF
--- a/src/main/java/com/floney/floney/settlement/dto/response/SettlementResponse.java
+++ b/src/main/java/com/floney/floney/settlement/dto/response/SettlementResponse.java
@@ -60,7 +60,7 @@ public class SettlementResponse {
         private Double money;
 
         private static DetailResponse from(final SettlementUser settlementUser) {
-            if (settlementUser.getUser() == null) {
+            if (settlementUser.getUser() == null || !settlementUser.isActive()) {
                 return DetailResponse.builder()
                     .userNickname(User.DELETE_VALUE)
                     .userProfileImg(null)


### PR DESCRIPTION
## 📌 개요

가계부에서 나간 유저도 정산 시 '알수없음' 으로 처리했습니다.

